### PR TITLE
feat(HACBS-2107): Add Network Policy to internl-service controller

### DIFF
--- a/internal-services/config/networkpolicy/production/network_policy.yaml
+++ b/internal-services/config/networkpolicy/production/network_policy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-external-cluster
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Egress
+  egress:
+    - to:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            apiserver: "true"
+            app: openshift-kube-apiserver
+      ports:
+        - port: 6443
+        - port: 80
+        - port: 443
+          protocol: TCP
+    - to:
+      - ipBlock:
+          cidr: 44.195.126.208/32  # Hypershift-Dev
+      ports:
+        - port: 6443
+        - port: 80
+        - port: 443
+          protocol: TCP
+    - to:
+      - ipBlock:
+          cidr: 54.91.12.133/32  # RHTAP-Prod
+      ports:
+        - port: 6443
+        - port: 80
+        - port: 443
+          protocol: TCP

--- a/internal-services/config/networkpolicy/staging/network_policy.yaml
+++ b/internal-services/config/networkpolicy/staging/network_policy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-external-cluster
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Egress
+  egress:
+    - to:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            apiserver: "true"
+            app: openshift-kube-apiserver
+      ports:
+        - port: 6443
+        - port: 80
+        - port: 443
+          protocol: TCP
+    - to:
+      - ipBlock:
+          cidr: 44.195.126.208/32  # Hypershift-Dev
+      ports:
+        - port: 6443
+        - port: 80
+        - port: 443
+          protocol: TCP
+    - to:
+      - ipBlock:
+          cidr: 52.202.122.112/32  # RHTAP-Stage
+      ports:
+        - port: 6443
+        - port: 80
+        - port: 443
+          protocol: TCP


### PR DESCRIPTION
The following commit adds an Egress Network Policy to the internal-service app-interface cluster,
only allowing traffic to listed `ipBlock` and blocking the rest of the traffic from the cluster for better security