### PR TITLE
fix: remove jq -cr param to keep result as string

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -156,7 +156,7 @@ spec:
             esac
         done
         echo
-        jq -cr '{ "state": .state, "state_reason": .state_reason }' $(results.jsonBuildInfo.path) \
+        jq -cr '{ "state": .state, "state_reason": .state_reason }' $(results.jsonBuildInfo.path) | jq -Rc \
         | tee $(results.buildState.path)
         test \${state} = "complete" && exit 0 || exit 1
         SH


### PR DESCRIPTION
Fix the output saved in `buildState` result to be always a regular string. For some reason the `-cr` param is making openshift understand the result as an object.

https://console-openshift-console.apps.appsres03ue1.5nvu.p1.openshiftapps.com/k8s/ns/stonesoup-int-srvc/tekton.dev~v1beta1~PipelineRun/internalrequest-cph6h