### PR TITLE
add more IP CIDR to network policy

### DIFF
--- a/internal-services/config/networkpolicy/production/network_policy.yaml
+++ b/internal-services/config/networkpolicy/production/network_policy.yaml
@@ -22,15 +22,11 @@ spec:
           protocol: TCP
     - to:
       - ipBlock:
-          cidr: 44.195.126.208/32  # Hypershift-Dev
-      ports:
-        - port: 6443
-        - port: 80
-        - port: 443
-          protocol: TCP
-    - to:
-      - ipBlock:
           cidr: 54.91.12.133/32  # RHTAP-Prod
+      - ipBlock:
+          cidr: 34.200.117.205/32
+      - ipBlock:
+          cidr: 54.159.168.255/32
       ports:
         - port: 6443
         - port: 80

--- a/internal-services/config/networkpolicy/staging/network_policy.yaml
+++ b/internal-services/config/networkpolicy/staging/network_policy.yaml
@@ -23,6 +23,14 @@ spec:
     - to:
       - ipBlock:
           cidr: 44.195.126.208/32  # Hypershift-Dev
+      - ipBlock:
+          cidr: 34.231.201.235/32
+      - ipBlock:
+          cidr: 3.220.20.59/32
+      - ipBlock:
+          cidr: 44.195.63.86/32
+      - ipBlock:
+          cidr: 18.210.102.59/32
       ports:
         - port: 6443
         - port: 80
@@ -31,6 +39,10 @@ spec:
     - to:
       - ipBlock:
           cidr: 52.202.122.112/32  # RHTAP-Stage
+      - ipBlock:
+          cidr: 34.192.134.220/32
+      - ipBlock:
+          cidr: 3.213.137.254/32
       ports:
         - port: 6443
         - port: 80


### PR DESCRIPTION
This commit will add more IP CIDR to the network policy
to allow better coverage and reliability. And also removes 
Hypershift target from the prod Network policy.