### PR TITLE
allow egress in prod Netowrk Policy

### DIFF
--- a/internal-services/config/networkpolicy/production/network_policy.yaml
+++ b/internal-services/config/networkpolicy/production/network_policy.yaml
@@ -9,26 +9,4 @@ spec:
   policyTypes:
   - Egress
   egress:
-    - to:
-      - namespaceSelector: {}
-        podSelector:
-          matchLabels:
-            apiserver: "true"
-            app: openshift-kube-apiserver
-      ports:
-        - port: 6443
-        - port: 80
-        - port: 443
-          protocol: TCP
-    - to:
-      - ipBlock:
-          cidr: 54.91.12.133/32  # RHTAP-Prod
-      - ipBlock:
-          cidr: 34.200.117.205/32
-      - ipBlock:
-          cidr: 54.159.168.255/32
-      ports:
-        - port: 6443
-        - port: 80
-        - port: 443
-          protocol: TCP
+    - {}  # allow all egress


### PR DESCRIPTION
This commit allow egress to all. In order for change to be applied in prod we need an MR in the [app-interface](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/stonesoup/internal-services/cicd/stonesoup-internal-services.appsrep05ue1.yaml#L75l) repo for updating `ref`.