### PR TITLE
fix: removes default value for `publishingCredentials`

### DIFF
--- a/internal-services/catalog/publish-index-image-pipeline.yaml
+++ b/internal-services/catalog/publish-index-image-pipeline.yaml
@@ -24,7 +24,6 @@ spec:
       description: Number of skopeo retries
     - name: publishingCredentials
       type: string
-      default: "fbc-publishing-credentials"
       description: The credentials used to access the registries
     - name: requestUpdateTimeout
       type: string


### PR DESCRIPTION
Fix: The parameter `publishingCredentials` for the `publish-index-image` Pipeline should have no default set

Ref: https://github.com/redhat-appstudio/release-service-bundles/pull/133