### PR TITLE
fix: remove default values from iibServiceConfigSecret and iibFromImageOverwriteCredentials

### DIFF
--- a/internal-services/catalog/iib-pipeline.yaml
+++ b/internal-services/catalog/iib-pipeline.yaml
@@ -19,11 +19,9 @@ spec:
     - name: iibServiceConfigSecret
       type: string
       description: Secret containing IIB service Config
-      default: iib-services-config
     - name: iibFromImageOverwriteCredentials
       type: string
       description: Secret with overwrite FromImage credentials to be passed to IIB
-      default: iib-overwrite-fromimage-credentials
     - name: iibServiceAccountSecret
       type: string
       description: Secret containing the credentials for IIB service


### PR DESCRIPTION
With pre-GA (preview) FBC components we must allow these values to be rewritten by the releasestrategy and we will need different credentials per `fromIndex/targetIndex` pair.