### PR TITLE
fix: adjusts to fit the new pre-ga release strategy

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -39,9 +39,9 @@ spec:
     - name: iibServiceConfigSecret
       type: string
       description: Secret with IIB service config to be used
-    - name: iibFromImageOverwriteCredentials
+    - name: iibOverwriteFromIndexCredential
       type: string
-      description: Secret with overwrite FromImage credentials to be passed to IIB
+      description: Secret with overwrite FromIndex credentials to be passed to IIB
     - name: iibServiceAccountSecret
       type: string
       description: Secret with IIB credentials to be used
@@ -65,12 +65,12 @@ spec:
         - name: IIB_OVERWRITE_FROM_INDEX_USERNAME
           valueFrom:
             secretKeyRef:
-              name: $(params.iibFromImageOverwriteCredentials)
+              name: $(params.iibOverwriteFromIndexCredential)
               key: username
         - name: IIB_OVERWRITE_FROM_INDEX_TOKEN
           valueFrom:
             secretKeyRef:
-              name: $(params.iibFromImageOverwriteCredentials)
+              name: $(params.iibOverwriteFromIndexCredential)
               key: token
         - name: KRB5_CONF_CONTENT
           valueFrom:

--- a/internal-services/catalog/iib-pipeline.yaml
+++ b/internal-services/catalog/iib-pipeline.yaml
@@ -18,12 +18,12 @@ spec:
       description: The Snapshot in JSON format
     - name: iibServiceConfigSecret
       type: string
-      description: Secret containing IIB service Config
       default: iib-services-config
-    - name: iibFromImageOverwriteCredentials
+      description: Secret containing IIB service Config
+    - name: iibOverwriteFromIndexCredential
       type: string
-      description: Secret with overwrite FromImage credentials to be passed to IIB
       default: iib-overwrite-fromimage-credentials
+      description: Secret with overwrite FromImage credentials to be passed to IIB
     - name: iibServiceAccountSecret
       type: string
       description: Secret containing the credentials for IIB service
@@ -57,8 +57,8 @@ spec:
           value: $(params.binaryImage)
         - name: iibServiceConfigSecret
           value: $(params.iibServiceConfigSecret)
-        - name: iibFromImageOverwriteCredentials
-          value: $(params.iibFromImageOverwriteCredentials)
+        - name: iibOverwriteFromIndexCredential
+          value: $(params.iibOverwriteFromIndexCredential)
         - name: iibServiceAccountSecret
           value: $(params.iibServiceAccountSecret)
         - name: fbcFragment


### PR DESCRIPTION
FBC pre-GA release strategy requires different credentials, so we should be able to set them.