### PR TITLE
fix: only run yamllint on catalog and not the rest

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Run yamllint
         uses: frenck/action-yamllint@v1
         with:
-          path: internal-services/
+          path: internal-services/catalog/
   tknparse:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
All the yaml files except for the catalog are automatically
updated from the internal-services repo (and they are auto generated
by a Makefile there). So every time the files are updated,
they violate yamllint rules. It's better to exclude them
altogether and only run yamllint on the catalog subdir
(which is updated manually).

Issue found by David.