### PR TITLE
fix: move shell line break outside jq expression

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -108,8 +108,8 @@ spec:
 
         # check if this fbc fragment is opt-in
         echo "Fetching the image bundle from $(params.fbcFragment)..."
-        PULL_SPEC_LIST=$(opm render $(params.fbcFragment) | jq -r 'select(.schema == "olm.bundle") \
-          | "\(.image)" | split("@")[0]' |uniq)
+        PULL_SPEC_LIST=$(opm render $(params.fbcFragment) | jq -r \
+        'select(.schema == "olm.bundle") | "\(.image)" | split("@")[0]' |uniq)
         for PULL_SPEC in ${PULL_SPEC_LIST}; do
             # make sure they query is done using the internal name instead of the public
             PULL_SPEC=$(sed  's/registry.redhat.io/registry.access.redhat.com/g' <<< $PULL_SPEC)


### PR DESCRIPTION
This PR moves the shell line break added inside the jq query expression to the right place.