### PR TITLE
fix: rebase before MR

### DIFF
--- a/internal-services/catalog/file-updates-process-file-updates-task.yaml
+++ b/internal-services/catalog/file-updates-process-file-updates-task.yaml
@@ -33,7 +33,7 @@ spec:
       description: fileUpdates state
   steps:
     - name: perform-updates
-      image: quay.io/hacbs-release/release-utils:df8d2074895a6ab9a2e433ee707ad475524dfc1e
+      image: quay.io/hacbs-release/release-utils:06643f9e7c2b6ddf5e095bc735ce7c308793815d
       env:
         - name: GITLAB_HOST
           valueFrom:
@@ -63,10 +63,13 @@ spec:
           . /home/utils/gitlab-functions
           . /home/utils/git-functions
 
+          TEMP=$(mktemp -d /tmp/file-updates.XXXX)
+
           gitlab_init
+          git_functions_init
 
           # saves the params.paths json to a file
-          updatePathsTmpfile="/tmp/updatePaths.json"
+          updatePathsTmpfile="${TEMP}/updatePaths.json"
           cat > "${updatePathsTmpfile}" << JSON
           $(params.paths)
           JSON
@@ -77,8 +80,11 @@ spec:
 
           echo -e "=== UPDATING ${REPO} ON BRANCH ${REVISION} ===\n"
 
-          cd /tmp/
+          cd "${TEMP}"
           git_clone_and_checkout --repository "${REPO}" --revision "${REVISION}"
+
+          # updating local branch with the upstream
+          git_rebase -n "glab-base" -r "${UPSTREAM_REPO}" -v "${REVISION}"
 
           # getting the files that have replacements
           PATHS_LENGTH="$(jq '. | length' ${updatePathsTmpfile})"
@@ -124,10 +130,10 @@ spec:
           echo "Creating Pull Request..."
           GITLAB_MR_MSG="fileUpdates changes ${WORKING_BRANCH}"
           gitlab_create_mr --head $WORKING_BRANCH --target-branch $REVISION --title "chore: ${GITLAB_MR_MSG}" \
-              --description "${GITLAB_MR_MSG}" --upstream-repo "${UPSTREAM_REPO}"  \
-              | jq -c |jq -R |tee $(results.fileUpdatesInfo.path)
+              --description "${GITLAB_MR_MSG}" --upstream-repo "${UPSTREAM_REPO}" | jq '. |tostring' \
+              |tee $(results.fileUpdatesInfo.path)
+
           echo "Success" |tee $(results.fileUpdatesState.path)
 
           echo -e "=== FINISHED. CLEANING UP ===\n"
-          cd /tmp
-          rm -rf ${OLDPWD}
+          rm -rf ${TEMP}


### PR DESCRIPTION
fix: the task should rebase the branch before create the MR

This PR changes the task `process-file-updates` to rebase
the current branch with the upstream repo and given revision
before creating the MR

Signed-off-by: Leandro Mendes <lmendes@redhat.com>