### PR TITLE
feat(RHTAPREL-622): add new configmaps for signing

### DIFF
--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-openshifthosted.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-openshifthosted.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: production
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-openshifthosted"
+data:
+  PYXIS_URL: "https://pyxis.engineering.redhat.com"
+  SIG_KEY_ID: "B906BA72"
+  SIG_KEY_NAME: "openshifthosted"
+  SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-redhatrelease2.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-redhatrelease2.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: production
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-redhatrelease2"
+data:
+  PYXIS_URL: "https://pyxis.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/FD431D51 SHA-256"
+  SIG_KEY_NAME: "redhatrelease2"
+  SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/internal-services/config/signing/staging/hacbs-signing-pipeline-config-openshifthosted.yaml
+++ b/internal-services/config/signing/staging/hacbs-signing-pipeline-config-openshifthosted.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-openshifthosted"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
+  UMB_URL: "umb.stage.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/internal-services/config/signing/staging/hacbs-signing-pipeline-config-redhatrelease2.yaml
+++ b/internal-services/config/signing/staging/hacbs-signing-pipeline-config-redhatrelease2.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-redhatrelease2"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
+  UMB_URL: "umb.stage.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign


### PR DESCRIPTION
- hacbs-signing-pipeline-config-openshifthosted
- hacbs-signing-pipeline-config-redhatrelease2

Contents based on https://docs.engineering.redhat.com/display/PRODSEC/Signing+Server+User+Guide#SigningServerUserGuide-3.SigningKeysInUse

These configMaps will be specified in the release pipeline.