### PR TITLE
refactor(RHTAPREL-643): update create-advisory task logic

### DIFF
--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -58,19 +58,21 @@ spec:
               key: git_author_email
       script: |
           #!/usr/bin/env sh
-          set -ox pipefail
+          set -eo pipefail
 
-          # This should get overwritten if any command fails
-          echo -n "Success" > $(results.result.path)
-
-          failfunc() {
+          exitfunc() {
               local err=$1
               local line=$2
               local command="$3"
-              echo -n "$0: ERROR '$command' failed at line $line - exited with status $err" > $(results.result.path)
-              exit 0 # exit the script cleanly as there is no point in proceeding past an error
+              if [ $err -eq 0 ] ; then
+                  echo -n "Success" > $(results.result.path)
+              else
+                  echo -n "$0: ERROR '$command' failed at line $line - exited with status $err" > $(results.result.path)
+              fi
+              exit 0 # exit the script cleanly as there is no point in proceeding past an error or exit call
           }
-          trap 'failfunc $? $LINENO "$BASH_COMMAND"' ERR # the task should never fail with nonzero exit code
+          # due to set -e, this catches all EXIT and ERR calls and the task should never fail with nonzero exit code
+          trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
 
           REPO_BRANCH=main
           REPO=$(jq -r '.repo' <<< '$(params.advisory_json)')

--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,7 +34,7 @@ spec:
       description: Success if the task succeeds, the error otherwise
   steps:
     - name: create-advisory
-      image: quay.io/hacbs-release/release-utils:518c0423a3b3502c7b9ef6fd8652995bec2b4e1a
+      image: quay.io/hacbs-release/release-utils:6fe50b65600418f9b046c32733fc896a4df02d41
       env:
         - name: GITLAB_HOST
           valueFrom:
@@ -81,35 +81,18 @@ spec:
           gitlab_init
           git_functions_init
 
-          function get_advisory_num {
-              # This function will skip many advisory numbers as it is so tied to date. Need to
-              # discover if skipping advisory numbers like this is okay.
-              # There is also a race condition picking the advisory number like this.
-              EXISTING=$(for advisory in $(find data/advisories/*/${1} -name "advisory.yaml") ; do
-                  yq '.metadata.name' $advisory | grep ":${2}" || true
-              done | sort -r | head -n 1)
-              if [[ ! -z "$EXISTING" ]] ; then
-                  echo "${2}$((${EXISTING:9}+1))" # Strip first 9 chars for YYYY:MMDD then add 1
-                  return
-              fi
-              echo "${2}0" # First advisory of the day
-          }
-
           # This also cds into the git repo
           git_clone_and_checkout --repository "$REPO" --revision "$REPO_BRANCH"
 
-          YEAR=$(date '+%Y')
-          ADVISORY_DIR="data/advisories/$(params.origin)/${YEAR}" # group advisories by <origin workspace>/year
-          ADVISORY_NUM=$(get_advisory_num $YEAR $(date '+%m%d'))
-          ADVISORY_NAME="${YEAR}:${ADVISORY_NUM}"
-          ADVISORY_FILEPATH="${ADVISORY_DIR}/${ADVISORY_NUM}/advisory.yaml"
-          mkdir -p "${ADVISORY_DIR}/${ADVISORY_NUM}"
+          ADVISORY_DIR="staging/advisories/$(params.origin)/$(date '+%Y')" # group advisories by <origin workspace>/year
+          mkdir -p "${ADVISORY_DIR}"
+          ADVISORY_FILEPATH="${ADVISORY_DIR}/$(uuidgen).yaml"
 
           # Create advisory file
           /home/utils/apply_template.py -o $ADVISORY_FILEPATH --template /home/templates/advisory.yaml.jinja \
-          --data '{"advisory_name":"'$ADVISORY_NAME'","advisory":$(params.advisory_json)}'
+          --data '{"advisory":$(params.advisory_json)}'
 
           git add ${ADVISORY_FILEPATH}
-          git commit -m "[RHTAP Release] $(params.application): new advisory ${ADVISORY_NAME}"
+          git commit -m "[RHTAP Release] new advisory for $(params.application)"
           echo "Pushing to ${REPO_BRANCH}..."
-          git push origin $REPO_BRANCH
+          git_push_with_retries --branch $REPO_BRANCH --retries 5 --url origin

--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -34,7 +34,7 @@ spec:
       description: Success if the task succeeds, the error otherwise
   steps:
     - name: create-advisory
-      image: quay.io/hacbs-release/release-utils:6fe50b65600418f9b046c32733fc896a4df02d41
+      image: quay.io/redhat-appstudio/release-service-utils:a53a795550a73046617c9e3dff5ab0b8d3a45d6e
       env:
         - name: GITLAB_HOST
           valueFrom:

--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -41,6 +41,9 @@ spec:
             secretKeyRef:
               name: create-advisory-secret
               key: gitlab_host
+        # This is a GitLab Project access token. Go to the settings/access_tokens page
+        # of your repository to create one. It should have the Developer role with read
+        # and write repository rights.
         - name: ACCESS_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This commit changes the create-advisory task to push the advisories to a staging directory. The advisory name is also just a uuidgen now, as a gitlab ci pipeline will do that part instead. The logic that was present to help determine the advisory name is removed.

In addition, the error and trap handling in the task was updated