### PR TITLE
fix: reset array while setting the new value

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -121,7 +121,7 @@ spec:
             fbcOptIn+=(`isfbcOptIn ${PULL_SPEC}`)
         done
 
-        fbcOptIn=$(printf "%s\n" ${fbcOptIn[@]} |sort |uniq)
+        fbcOptIn=($(printf "%s\n" ${fbcOptIn[@]} |sort |uniq))
         mustPublishIndexImage=$fbcOptIn
         mustSignIndexImage=$fbcOptIn
 


### PR DESCRIPTION
This PR fix the value assignment that should reset the array when assigning the new value.

When `uniq` return a single value, the array should contain a single item, not multiple as 
it is happening when the fragment has multiple images, causing it to always enter a condition
that is not the one wanted (ie. having multiple images with different `fbc_opt_in` values).