### PR TITLE
refactor(RHTAPREL-773): pass advisory.spec in advisory task

### DIFF
--- a/internal-services/catalog/create-advisory-pipeline.yaml
+++ b/internal-services/catalog/create-advisory-pipeline.yaml
@@ -16,7 +16,7 @@ spec:
       type: string
       description: |
           String containing a JSON representation of the advisory data. It should not contain the `advisory`
-          top level key (e.g. '{"repo":"myrepo","spec":{"product_id":123,"type":"RHSA"}}')
+          top level key (e.g. '{"product_id":123,"type":"RHSA"}')
     - name: application
       type: string
       description: Application being released

--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -95,7 +95,7 @@ spec:
 
           # Create advisory file
           /home/utils/apply_template.py -o $ADVISORY_FILEPATH --template /home/templates/advisory.yaml.jinja \
-          --data '{"advisory":$(params.advisory_json)}'
+          --data '{"advisory":{"spec":$(params.advisory_json)}}'
 
           git add ${ADVISORY_FILEPATH}
           git commit -m "[RHTAP Release] new advisory for $(params.application)"


### PR DESCRIPTION
advisory.spec in the data.json is becoming releaseNotes. The template is not changing, however. So, this commit updates the create-advisory-task to pass advisory.spec to the template instead of just advisory to make up for that .spec field no longer existing in the data.json.