### PR TITLE
feat(RHTAPREL-799): add ship date to advisory

### DIFF
--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "0.7"
+    app.kubernetes.io/version: "0.8"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -41,7 +41,7 @@ spec:
       description: The advisory url if the task succeeds, empty string otherwise
   steps:
     - name: create-advisory
-      image: quay.io/redhat-appstudio/release-service-utils:d315777adea2aff34cd0ab28a85a139cae2f84b7
+      image: quay.io/redhat-appstudio/release-service-utils:8106fea3af80b7978c599dd9fc8cee0a679f3f35
       env:
         - name: GITLAB_HOST
           valueFrom:
@@ -100,7 +100,9 @@ spec:
           # This will be replaced in RHTAPREL-811
           ADVISORY_NUM=$(((RND=RANDOM<<15|RANDOM)) ; echo ${RND: -6})
 
-          YEAR=$(date '+%Y')
+          # Use ISO 8601 format in UTC/Zulu time, e.g. 2024-03-06T17:27:38Z
+          SHIP_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          YEAR=${SHIP_DATE%%-*} # derive the year from the ship date
           # group advisories by <origin workspace>/year
           ADVISORY_DIR="data/advisories/$(params.origin)/${YEAR}/${ADVISORY_NUM}"
           mkdir -p "${ADVISORY_DIR}"
@@ -112,9 +114,14 @@ spec:
           advisoryJsonWithKey=$(jq -c --arg key "$signingKey" \
             '.content.images[] += {"signingKey": $key}' <<< '$(params.advisory_json)')
 
+          # Prepare variables for the advisory template
+          DATA=$(jq -c '{"advisory":{"spec":.}' <<< $advisoryJsonWithKey)
+          DATA=$(jq -c --arg advisory_name "$ADVISORY_NAME" --arg advisory_ship_date "$SHIP_DATE" \
+            '$ARGS.named + .' <<< $DATA)
+
           # Create advisory file
-          /home/utils/apply_template.py -o $ADVISORY_FILEPATH --template /home/templates/advisory.yaml.jinja \
-            --data '{"advisory_name":"'${ADVISORY_NAME}'","advisory":{"spec":'"${advisoryJsonWithKey}"'}}'
+          /home/utils/apply_template.py -o $ADVISORY_FILEPATH --data $DATA \
+            --template /home/templates/advisory.yaml.jinja
 
           git add ${ADVISORY_FILEPATH}
           git commit -m "[Konflux Release] new advisory for $(params.application)"


### PR DESCRIPTION
The advisory template now expects a new variable
to set metadata.ship_date in the advisory.

Depends on: https://github.com/redhat-appstudio/release-service-utils/pull/129