### PR TITLE
chore: use latest released image

### DIFF
--- a/internal-services/manager/production/manager-prod-rh01.yaml
+++ b/internal-services/manager/production/manager-prod-rh01.yaml
@@ -59,7 +59,7 @@ spec:
             - --leader-elect
             - --remote-cluster-config-file
             - /mnt/internal-services/remote-client-config/kubeconfig
-          image: quay.io/redhat-appstudio/internal-services:enable-leader-election-override
+          image: quay.io/redhat-appstudio/internal-services:aadd837450da2ebccefb3d607feeeaaf390140d6
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/production/manager-staging-p01.yaml
+++ b/internal-services/manager/production/manager-staging-p01.yaml
@@ -61,7 +61,7 @@ spec:
             - /mnt/internal-services/remote-client-config/kubeconfig
             - --leader-election-id
             - "staging-p01"
-          image: quay.io/redhat-appstudio/internal-services:enable-leader-election-override
+          image: quay.io/redhat-appstudio/internal-services:aadd837450da2ebccefb3d607feeeaaf390140d6
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/staging/manager-staging-p01.yaml
+++ b/internal-services/manager/staging/manager-staging-p01.yaml
@@ -61,7 +61,7 @@ spec:
             - /mnt/internal-services/remote-client-config/kubeconfig
             - --leader-election-id
             - "staging-p01"
-          image: quay.io/redhat-appstudio/internal-services:enable-leader-election-override
+          image: quay.io/redhat-appstudio/internal-services:aadd837450da2ebccefb3d607feeeaaf390140d6
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/staging/manager-staging-rh01.yaml
+++ b/internal-services/manager/staging/manager-staging-rh01.yaml
@@ -59,7 +59,7 @@ spec:
             - --leader-elect
             - --remote-cluster-config-file
             - /mnt/internal-services/remote-client-config/kubeconfig
-          image: quay.io/redhat-appstudio/internal-services:enable-leader-election-override
+          image: quay.io/redhat-appstudio/internal-services:aadd837450da2ebccefb3d607feeeaaf390140d6
           name: manager
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
- due to outage with chains, it was not possible to create a release earlier.
- this updated the manager files with the latest release image pullspec