### PR TITLE
fix: declare param as env var in advisory task

### DIFF
--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -81,9 +81,11 @@ spec:
             secretKeyRef:
               name: errata-service-account
               key: base64_keytab
+        - name: "ADVISORY_JSON"
+          value: "$(params.advisory_json)"
       script: |
           #!/usr/bin/env sh
-          set -eox pipefail
+          set -eo pipefail
 
           exitfunc() {
               local err=$1
@@ -112,6 +114,11 @@ spec:
           # This also cds into the git repo
           git_clone_and_checkout --repository $(params.repo) --revision "$REPO_BRANCH"
 
+          # Inject signing key into ADVISORY_JSON
+          signingKey=$(kubectl get configmap $(params.config_map_name) -o jsonpath="{.data.SIG_KEY_NAME}")
+          advisoryJsonWithKey=$(jq -c --arg key "$signingKey" \
+            '.content.images[] += {"signingKey": $key}' <<< "$ADVISORY_JSON")
+
           # write keytab to file
           echo -n ${SERVICE_ACCOUNT_KEYTAB} | base64 --decode > /tmp/keytab
           # workaround kinit: Invalid UID in persistent keyring name while getting default ccache
@@ -120,11 +127,6 @@ spec:
           kinit ${SERVICE_ACCOUNT_NAME} -k -t /tmp/keytab
           ID=$(curl --retry 3 --negotiate -u : ${ERRATA_API}/advisory/reserve_live_id -XPOST | jq -r '.live_id')
           ADVISORY_NUM=$(printf "%04d" $ID)
-
-          # Inject signing key into advisory_json
-          signingKey=$(kubectl get configmap $(params.config_map_name) -o jsonpath="{.data.SIG_KEY_NAME}")
-          advisoryJsonWithKey=$(jq -c --arg key "$signingKey" \
-            '.content.images[] += {"signingKey": $key}' <<< '$(params.advisory_json)')
 
           # Use ISO 8601 format in UTC/Zulu time, e.g. 2024-03-06T17:27:38Z
           SHIP_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
In order to support string values with single quotes in the advisory_json parameter of the create-advisory-task, the parameter is declared as an env variable for the task script instead of using the parameter directly. This commit also removes the set -x added in PR #96 as that was just added for debugging.