### PR TITLE
fix(KFLUXBUGS-1255): allow staging signing configmaps in prod

### DIFF
--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-openshifthosted.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-openshifthosted.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-staging-openshifthosted"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
+  UMB_URL: "umb.stage.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-staging-redhatbeta2"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
+  UMB_URL: "umb.stage.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatrelease2.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatrelease2.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-staging-redhatrelease2"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
+  UMB_URL: "umb.stage.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign


### PR DESCRIPTION
- in production, we can now enable requesting signatures from RADAS stage is the event a push to registry.stage.redhat.io is performed.
- use data.sign.configMapName: hacbs-signing-pipeline-config-staging-<keyName>
- images signed with these configMaps with be signed with the redhate2etesting key
- we must eventually add some logic in the CI tests of repo konflux-release-data to verify that the config maps for staging are only used for pushes to redhat-pending