### PR TITLE
fix: create-advisory-task operates in /tmp dir

### DIFF
--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -104,6 +104,7 @@ spec:
 
           REPO_BRANCH=main
           ADVISORY_URL=""
+          cd /tmp # Workaround fatal: could not create work tree dir Permission denied
 
           # loading git and gitlab functions
           . /home/utils/gitlab-functions


### PR DESCRIPTION
The create advisory task is throwing errors writing to / so cd to /tmp at the beginning of the task.