### PR TITLE
fix(KFLUXBUGS-1291): does not overwrite krb5.conf

### DIFF
--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -124,7 +124,9 @@ spec:
           echo -n ${SERVICE_ACCOUNT_KEYTAB} | base64 --decode > /tmp/keytab
           # workaround kinit: Invalid UID in persistent keyring name while getting default ccache
           export KRB5CCNAME=`mktemp`
-          sed -i '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf
+          # see https://stackoverflow.com/a/12308187
+          export KRB5_CONFIG=`mktemp`
+          sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
           kinit ${SERVICE_ACCOUNT_NAME} -k -t /tmp/keytab
           ID=$(curl --retry 3 --negotiate -u : ${ERRATA_API}/advisory/reserve_live_id -XPOST | jq -r '.live_id')
           ADVISORY_NUM=$(printf "%04d" $ID)


### PR DESCRIPTION
- in cases where you have a non-privileged container. we should to try to not overwrite /etc/krb5.conf