### PR TITLE
fix(RELEASE-928): remove hardcoded secret name

### DIFF
--- a/internal-services/catalog/create-advisory-pipeline.yaml
+++ b/internal-services/catalog/create-advisory-pipeline.yaml
@@ -28,6 +28,9 @@ spec:
     - name: config_map_name
       type: string
       description: The name of the configMap that contains the signing key
+    - name: advisory_secret_name
+      type: string
+      description: The name of the secret that contains the advisory creation metadata
   tasks:
     - name: create-advisory-task
       taskRef:
@@ -41,6 +44,8 @@ spec:
           value: $(params.origin)
         - name: config_map_name
           value: $(params.config_map_name)
+        - name: advisory_secret_name
+          value: $(params.advisory_secret_name)
   results:
     - name: result
       value: $(tasks.create-advisory-task.results.result)

--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -31,6 +31,9 @@ spec:
     - name: config_map_name
       type: string
       description: The name of the configMap that contains the signing key
+    - name: advisory_secret_name
+      type: string
+      description: The name of the secret that contains the advisory creation metadata
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -43,7 +46,7 @@ spec:
         - name: GITLAB_HOST
           valueFrom:
             secretKeyRef:
-              name: create-advisory-secret
+              name: $(params.advisory_secret_name)
               key: gitlab_host
         # This is a GitLab Project access token. Go to the settings/access_tokens page
         # of your repository to create one. It should have the Developer role with read
@@ -51,22 +54,22 @@ spec:
         - name: ACCESS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: create-advisory-secret
+              name: $(params.advisory_secret_name)
               key: gitlab_access_token
         - name: GIT_AUTHOR_NAME
           valueFrom:
             secretKeyRef:
-              name: create-advisory-secret
+              name: $(params.advisory_secret_name)
               key: git_author_name
         - name: GIT_AUTHOR_EMAIL
           valueFrom:
             secretKeyRef:
-              name: create-advisory-secret
+              name: $(params.advisory_secret_name)
               key: git_author_email
         - name: GIT_REPO
           valueFrom:
             secretKeyRef:
-              name: create-advisory-secret
+              name: $(params.advisory_secret_name)
               key: git_repo
         - name: ERRATA_API
           valueFrom:


### PR DESCRIPTION
- pipeline and task for create-advisory was correct to no longer use a hard-coded secret name. It is now a parameter.
- that parameter is already sent in the release pipeline and passed in the InternalRequest.