### PR TITLE
fix(RELEASE-948): hotfix feature not working properly

### DIFF
--- a/internal-services/catalog/publish-index-image-task.yaml
+++ b/internal-services/catalog/publish-index-image-task.yaml
@@ -53,7 +53,7 @@ spec:
         export PATH
 
         # do not authenticate if the source is redhat's "registry-proxy" which is unauthenticated.
-        if [[ "$(params.sourceIndex)" =~ ^registry-proxy(\/stage)?.engineering.redhat.com ]]; then
+        if [[ ! "$(params.sourceIndex)" =~ ^registry-proxy(\-stage)?.engineering.redhat.com ]]; then
             AUTH_PARAM="--src-creds ${SOURCE_INDEX_CREDENTIAL}"
         fi
 


### PR DESCRIPTION
This commit fixes the behavior when the sourceIndex is
an internal pullspec, which does not required auth.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>