### PR TITLE
chore: renaming manager role

### DIFF
--- a/internal-services/rbac/role.yaml
+++ b/internal-services/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: internal-services-manager-role
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/internal-services/rbac/role_binding.yaml
+++ b/internal-services/rbac/role_binding.yaml
@@ -9,11 +9,11 @@ metadata:
     app.kubernetes.io/created-by: internal-services
     app.kubernetes.io/part-of: internal-services
     app.kubernetes.io/managed-by: kustomize
-  name: manager-rolebinding
+  name: internal-services-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: internal-services-manager-role
 subjects:
   - kind: ServiceAccount
     name: controller-manager


### PR DESCRIPTION
renaming "manager-role" to  "internal-services-manager-role" and  "internal-service-role-binding"
to create clarity about what this role and binding do.