### PR TITLE
fix(RELEASE-926): update KRB5_CONFIG

### DIFF
--- a/internal-services/catalog/check-embargoed-cves-task.yaml
+++ b/internal-services/catalog/check-embargoed-cves-task.yaml
@@ -68,7 +68,8 @@ spec:
           echo -n ${SERVICE_ACCOUNT_KEYTAB} | base64 --decode > /tmp/keytab
           # workaround kinit: Invalid UID in persistent keyring name while getting default ccache
           export KRB5CCNAME=`mktemp`
-          sed -i '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf
+          export KRB5_CONFIG=`mktemp`
+          sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
           kinit ${SERVICE_ACCOUNT_NAME} -k -t /tmp/keytab
 
           RC=0

--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -110,8 +110,9 @@ spec:
         # performs kerberos authentication.
         base64 -d /mnt/service-account-secret/keytab > /tmp/keytab
 
-        echo "${KRB5_CONF_CONTENT}" > /tmp/krb5.conf
-        export KRB5_CONFIG=/tmp/krb5.conf
+        KRB5_TEMP_CONF=$(mktemp)
+        echo "${KRB5_CONF_CONTENT}" > "${KRB5_TEMP_CONF}"
+        export KRB5_CONFIG="${KRB5_TEMP_CONF}"
 
         /usr/bin/kinit -V $(cat /mnt/service-account-secret/principal) -k -t /tmp/keytab
 


### PR DESCRIPTION
* Update KRB5_CONFIG to use temporary storage to avoid permission errors after cluster migration