### PR TITLE
fix: renaming the role back to internal-services-manager-rolebinding

### DIFF
--- a/internal-services/rbac/role.yaml
+++ b/internal-services/rbac/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: internal-services-manager-role
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/internal-services/rbac/role_binding.yaml
+++ b/internal-services/rbac/role_binding.yaml
@@ -3,16 +3,16 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/instance: internal-services-manager-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: internal-services
     app.kubernetes.io/part-of: internal-services
     app.kubernetes.io/managed-by: kustomize
-  name: manager-rolebinding
+  name: internal-services-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: internal-services-manager-role
 subjects:
   - kind: ServiceAccount
     name: controller-manager


### PR DESCRIPTION
This PR renames the ClusterRole and RoleBinding with the prefix `internal-services`.