### PR TITLE
fix(KFLUXBUGS-1282): (stable) InternalServiceConfigs are not stored in git

### DIFF
--- a/internal-services/config/internal-services/internal-services/config/internal-services/production/internal-services-config.yaml
+++ b/internal-services/config/internal-services/internal-services/config/internal-services/production/internal-services-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: InternalServicesConfig
+metadata:
+  name: config
+  namespace: stonesoup-int-srvc
+spec:
+  allowList:
+  - rhtap-releng-tenant
+  - rh-managed-cnv-fbc-tenant
+  - rh-managed-red-hat-acm-tenant
+  debug: true
+  volumeClaim:
+    name: pipeline
+    size: 1Gi

--- a/internal-services/config/internal-services/internal-services/config/internal-services/staging/internal-services-config.yaml
+++ b/internal-services/config/internal-services/internal-services/config/internal-services/staging/internal-services-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: InternalServicesConfig
+metadata:
+  name: config
+  namespace: stonesoup-int-srvc
+spec:
+  allowList:
+  - managed-release-team-tenant
+  - rhtap-releng-tenant-removed-since-we-want-to-ship-from-prod
+  debug: true
+  volumeClaim:
+    name: pipeline
+    size: 1Gi


### PR DESCRIPTION
This commit adds the InternalServiceConfigs config definitions
so they can be fetched and applied in the prod and stage appsre
ocp clusters.

Signed-off-by: Leandro Mendes lmendes@redhat.com