### PR TITLE
refactor(RELEASE-977): migrate internal-services quay org

### DIFF
--- a/internal-services/manager/manager.yaml
+++ b/internal-services/manager/manager.yaml
@@ -59,7 +59,7 @@ spec:
             - --leader-elect
             - --remote-cluster-config-file
             - /mnt/internal-services/remote-client-config/kubeconfig
-          image: quay.io/redhat-appstudio/internal-services:aadd837450da2ebccefb3d607feeeaaf390140d6
+          image: quay.io/konflux-ci/internal-services:6edb83adc79ac8a01f7acf8f2526e78aff900a2c
           name: manager
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
This commit updates the quay image reference for the internal-services manager to the new location in the konflux-ci quay org as well as updating to the latest commit as that is the only image available in the new quay location.