### PR TITLE
fix: increase verbosity

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -116,6 +116,7 @@ spec:
 
         /usr/bin/kinit -V $(cat /mnt/service-account-secret/principal) -k -t /tmp/keytab
 
+        set -x
         # check if this fbc fragment is opt-in
         echo "Fetching the image bundle from $(params.fbcFragment)..."
         PULL_SPEC_LIST=$(opm render $(params.fbcFragment) | jq -r \


### PR DESCRIPTION
this commit increases the verbosity of the `iib-add-fbc-fragment-to-index-image-task`
by adding a `set -x` to it.