### PR TITLE
feat(RELEASE-1006): update references to `release-service-utils`

### DIFF
--- a/internal-services/catalog/check-embargoed-cves-task.yaml
+++ b/internal-services/catalog/check-embargoed-cves-task.yaml
@@ -27,7 +27,7 @@ spec:
       description: Space separated string of embargoed CVEs if any are found, empty string otherwise
   steps:
     - name: check-embargoed-cves
-      image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       env:
         - name: SERVICE_ACCOUNT_NAME
           valueFrom:

--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -41,7 +41,7 @@ spec:
       description: The advisory url if the task succeeds, empty string otherwise
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       env:
         - name: GITLAB_HOST
           valueFrom:

--- a/internal-services/catalog/file-updates-process-file-updates-task.yaml
+++ b/internal-services/catalog/file-updates-process-file-updates-task.yaml
@@ -36,7 +36,7 @@ spec:
       description: fileUpdates state
   steps:
     - name: perform-updates
-      image: quay.io/hacbs-release/release-utils:2716cf0a7853d9d55ec4a56b052ac4b57fef4fdc
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       env:
         - name: GITLAB_HOST
           valueFrom:

--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -65,7 +65,7 @@ spec:
   steps:
     - name: s-add-fbc-fragment-to-index-image
       image: >-
-        quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       env:
         - name: IIB_SERVICE_URL
           valueFrom:
@@ -201,7 +201,7 @@ spec:
           mountPath: /mnt/service-account-secret
     - name: s-wait-for-build-state
       image: >-
-        quay.io/konflux-ci/release-service-utils:38c3bfd7479c86b832cba5b61f9bbde40c469393
+        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       env:
         - name: IIB_SERVICE_URL
           valueFrom:

--- a/internal-services/catalog/publish-index-image-task.yaml
+++ b/internal-services/catalog/publish-index-image-task.yaml
@@ -46,7 +46,7 @@ spec:
               key: targetIndexCredential
               name: $(params.publishingCredentials)
       image: >-
-        quay.io/hacbs-release/release-utils:06643f9e7c2b6ddf5e095bc735ce7c308793815d
+        quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
       script: |
         #!/usr/bin/env sh
         PATH=/bin:/usr/bin:/usr/local/bin


### PR DESCRIPTION
This commit addresses [CVE-2024-3727](https://github.com/advisories/GHSA-6wvf-f2vw-3425) by updating references and bumping images.

Changes include:
- Updating all references from quay.io/hacbs-release/release-service-utils
  to the latest available tag at quay.io/konflux-ci/release-service-utils.

- Bumping quay.io/konflux-ci/release-service-utils
  to the latest available tag.

Signed-off-by: Sean Conroy <sconroy@redhat.com>