### PR TITLE
fix(RELEASE-951): remove SARIF upload & integrate printout

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -62,12 +62,17 @@ jobs:
         id: checkton
         uses: chmeliik/checkton@v0.1.2 # Migrating to the konflux-ci org
         with:
-         # Let there be green. GitHub's code scanning will do the reporting.
-          fail-on-findings: false
+          fail-on-findings: true
           find-copies-harder: true
-      - name: Upload SARIF File
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: ${{ steps.checkton.outputs.sarif }}
-          # Avoid clashing with ShellCheck
-          category: checkton
+	continue-on-error: true
+      - name: View SARIF Checkton Results 
+        run: cat "${{ steps.checkton.outputs.sarif }}"
+      - name: Check if Checkton failed
+        run: |
+          if [ "${{ steps.checkton.outcome }}" != "success" ]; then
+            echo "Checkton found issues"
+            exit 1
+          else
+            echo "Checkton found no issues"
+          fi
+


### PR DESCRIPTION
Changes:
- Removed the SARIF upload step from the Checkton process.
- Implemented a printout of the Checkton SARIF results instead.

This change is based on the discussion in Slack:
https://redhat-internal.slack.com/archives/C04J47GL936/p1720721997823459