### PR TITLE
chore(RELEASE-1046): bump manager image

### DIFF
--- a/internal-services/manager/manager.yaml
+++ b/internal-services/manager/manager.yaml
@@ -59,7 +59,7 @@ spec:
             - --leader-elect
             - --remote-cluster-config-file
             - /mnt/internal-services/remote-client-config/kubeconfig
-          image: quay.io/redhat-appstudio/internal-services:736a6ec39d8248af7dfb1b10af8960a2fbd9dce6
+          image: quay.io/konflux-ci/internal-services:1f6e470ab440cea906daca1d1634dee1cfcca415
           name: manager
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Bump the manager image so that the operator passes the service account to the pipelinerun.