### PR TITLE
chore: bump main to stable for RELEASE-1045

### DIFF
--- a/internal-services/catalog/pulp-push-disk-images-pipeline.yaml
+++ b/internal-services/catalog/pulp-push-disk-images-pipeline.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: push-disk-images
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+spec:
+  description: >-
+      Pipeline to push disk images with pulp
+  params:
+    - name: snapshot_json
+      type: string
+      description: String containing a JSON representation of the snapshot spec
+    - name: exodusGwSecret
+      type: string
+      description: Env specific secret containing the Exodus Gateway configs
+    - name: exodusGwEnv
+      type: string
+      description: Environment to use in the Exodus Gateway. Options are [live, pre]
+    - name: pulpSecret
+      type: string
+      description: Env specific secret containing the rhsm-pulp credentials
+    - name: udcacheSecret
+      type: string
+      description: Env specific secret containing the rhsm-pulp credentials
+  tasks:
+    - name: pulp-push-disk-images
+      timeout: "2h00m0s"
+      taskRef:
+        name: pulp-push-disk-images
+      params:
+        - name: snapshot_json
+          value: $(params.snapshot_json)
+        - name: exodusGwSecret
+          value: $(params.exodusGwSecret)
+        - name: exodusGwEnv
+          value: $(params.exodusGwEnv)
+        - name: pulpSecret
+          value: $(params.pulpSecret)
+        - name: udcacheSecret
+          value: $(params.udcacheSecret)
+  results:
+    - name: result
+      value: $(tasks.pulp-push-disk-images.results.result)

--- a/internal-services/catalog/pulp-push-disk-images-task.yaml
+++ b/internal-services/catalog/pulp-push-disk-images-task.yaml
@@ -1,0 +1,205 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: pulp-push-disk-images
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to push disk images with pulp
+  params:
+    - name: snapshot_json
+      type: string
+      description: String containing a JSON representation of the snapshot spec
+    - name: concurrentLimit
+      type: string
+      description: The maximum number of images to be pulled at once
+      default: 3
+    - name: exodusGwSecret
+      type: string
+      description: Env specific secret containing the Exodus Gateway configs
+    - name: exodusGwEnv
+      type: string
+      description: Environment to use in the Exodus Gateway. Options are [live, pre]
+    - name: pulpSecret
+      type: string
+      description: Env specific secret containing the rhsm-pulp credentials
+    - name: udcacheSecret
+      type: string
+      description: Env specific secret containing the udcache credentials
+  results:
+    - name: result
+      description: Success if the task succeeds, the error otherwise
+  steps:
+    - name: pull-and-push-images
+      image: quay.io/konflux-ci/release-service-utils:cff1fd1e9d8fabc256ff17f6731b2c037a0a1102
+      env:
+        - name: EXODUS_CERT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.exodusGwSecret)
+              key: cert
+        - name: EXODUS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.exodusGwSecret)
+              key: key
+        - name: EXODUS_URL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.exodusGwSecret)
+              key: url
+        - name: PULP_URL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pulpSecret)
+              key: pulp_url
+        - name: PULP_CERT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pulpSecret)
+              key: konflux-release-rhsm-pulp.crt
+        - name: PULP_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pulpSecret)
+              key: konflux-release-rhsm-pulp.key
+        - name: UDC_URL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.udcacheSecret)
+              key: url
+        - name: UDC_CERT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.udcacheSecret)
+              key: cert
+        - name: UDC_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.udcacheSecret)
+              key: key
+        - name: "SNAPSHOT_JSON"
+          value: "$(params.snapshot_json)"
+      script: |
+        #!/usr/bin/env bash
+        set -ex
+
+        STDERR_FILE=/tmp/stderr.txt
+
+        exitfunc() {
+            local err=$1
+            local line=$2
+            local command="$3"
+            if [ "$err" -eq 0 ] ; then
+                echo -n "Success" > "$(results.result.path)"
+            else
+                echo "$0: ERROR '$command' failed at line $line - exited with status $err" \
+                  > "$(results.result.path)"
+                if [ -f "$STDERR_FILE" ] ; then
+                    cat "$STDERR_FILE" | tail -n 20 >> "$(results.result.path)"
+                fi
+            fi
+            exit 0 # exit the script cleanly as there is no point in proceeding past an error or exit call
+        }
+        # due to set -e, this catches all EXIT and ERR calls and the task should never fail with nonzero exit code
+        trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
+
+        # Setup required variables
+        export EXODUS_GW_CERT=/tmp/exodus.crt
+        export EXODUS_GW_KEY=/tmp/exodus.key
+        export PULP_CERT_FILE=/tmp/pulp.crt
+        export PULP_KEY_FILE=/tmp/pulp.key
+        export UDCACHE_CERT=/tmp/udc.crt
+        export UDCACHE_KEY=/tmp/udc.key
+        EXODUS_GW_ENV=$(params.exodusGwEnv)
+        export EXODUS_GW_ENV
+        export EXODUS_GW_URL="$EXODUS_URL"
+        export EXODUS_PULP_HOOK_ENABLED=True
+        export EXODUS_GW_TIMEOUT=7200
+
+        set +x
+        echo "$EXODUS_CERT" > "$EXODUS_GW_CERT"
+        echo "$EXODUS_KEY" > "$EXODUS_GW_KEY"
+        echo "$PULP_CERT" > "$PULP_CERT_FILE"
+        echo "$PULP_KEY" > "$PULP_KEY_FILE"
+        echo "$UDC_CERT" > "$UDCACHE_CERT"
+        echo "$UDC_KEY" > "$UDCACHE_KEY"
+        set -x
+
+        DISK_IMAGE_DIR="$(mktemp -d)"
+
+        process_component() { # Expected argument is [component json]
+            COMPONENT=$1
+            PULLSPEC=$(jq -er '.containerImage' <<< "${COMPONENT}")
+            DESTINATION="${DISK_IMAGE_DIR}/$(jq -er '.staged.destination' <<< "${COMPONENT}")/FILES" \
+              || (echo Missing staged.destination value for component. This should be an existing pulp repo. Failing \
+              && exit 1)
+            mkdir -p "${DESTINATION}"
+            DOWNLOAD_DIR=$(mktemp -d)
+            cd "$DOWNLOAD_DIR"
+            # oras has very limited support for selecting the right auth entry,
+            # so create a custom auth file with just one entry
+            AUTH_FILE=$(mktemp)
+            select-oci-auth "${PULLSPEC}" > "$AUTH_FILE"
+            oras pull --registry-config "$AUTH_FILE" "$PULLSPEC"
+            NUM_MAPPED_FILES=$(jq '.staged.files | length' <<< "${COMPONENT}")
+            for ((i = 0; i < NUM_MAPPED_FILES; i++)) ; do
+                FILE=$(jq -c --arg i "$i" '.staged.files[$i|tonumber]' <<< "$COMPONENT")
+                SOURCE=$(jq -er '.source' <<< "$FILE")
+                FILENAME=$(jq -er '.filename' <<< "$FILE")
+                # The .qcow2 images are not zipped
+                if [ -f "${SOURCE}.gz" ] ; then
+                    gzip -d "${SOURCE}.gz"
+                fi
+                DESTINATION_FILE="${DESTINATION}/${FILENAME}"
+                # Albeit a rare one, this is a race condition since this is run in parallel.
+                # The race condition is if two files have the same $DESTINATION_FILE and both
+                # if checks are run before either mv is run a few lines below.
+                if [ -f "${DESTINATION_FILE}" ] ; then
+                    echo -n "Multiple files use the same destination value: $DESTINATION" >&2
+                    echo " and filename value: $FILENAME. Failing..." >&2
+                    exit 1
+                fi
+                mv "$SOURCE" "${DESTINATION_FILE}" || echo "didn't find mapped file: ${SOURCE}"
+            done
+        }
+
+        RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
+        NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
+        # Process each component in parallel
+        for ((i = 0; i < NUM_COMPONENTS; i++)) ; do
+            COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
+            # Limit batch size to concurrent limit
+            while (( ${RUNNING_JOBS@P} >= $(params.concurrentLimit) )); do
+                wait -n
+            done
+            process_component "$COMPONENT" 2> "$STDERR_FILE" &
+        done
+
+        # Wait for remaining processes to finish
+        while (( ${RUNNING_JOBS@P} > 0 )); do
+            wait -n
+        done
+
+        # Change to the subdir with the images
+        cd "${DISK_IMAGE_DIR}"
+
+        STAGED_JSON='{"header":{"version": "0.2"},"payload":{"files":[]}}'
+
+        # Add the files to the payload
+        while IFS= read -r -d '' file ; do
+            STAGED_JSON=$(jq --arg filename "$(basename "$file")" --arg path "$file" \
+              '.payload.files[.payload.files | length] = 
+              {"filename": $filename, "relative_path": $path}' <<< "$STAGED_JSON")
+        done < <(find * -type f -print0)
+
+        echo "$STAGED_JSON" | yq -P -I 4 > staged.yaml
+
+        pulp_push_wrapper --debug --source "${DISK_IMAGE_DIR}" --pulp-url "$PULP_URL" \
+          --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" \
+          2> "$STDERR_FILE"

--- a/internal-services/crds/appstudio.redhat.com_internalrequests.yaml
+++ b/internal-services/crds/appstudio.redhat.com_internalrequests.yaml
@@ -53,6 +53,30 @@ spec:
                   will be translated into a Tekton pipeline
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
+              serviceAccount:
+                description: ServiceAccount defines the serviceAccount to use in the
+                  InternalRequest PipelineRun execution. If none is passed, the default
+                  Tekton ServiceAccount will be used
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              timeouts:
+                description: Timeouts defines the different Timeouts to use in the
+                  InternalRequest PipelineRun execution
+                properties:
+                  finally:
+                    description: Finally sets the maximum allowed duration of this
+                      pipeline's finally
+                    type: string
+                  pipeline:
+                    description: Pipeline sets the maximum allowed duration for execution
+                      of the entire pipeline. The sum of individual timeouts for tasks
+                      and finally must not exceed this value.
+                    type: string
+                  tasks:
+                    description: Tasks sets the maximum allowed duration of this pipeline's
+                      tasks
+                    type: string
+                type: object
             required:
             - request
             type: object

--- a/internal-services/manager/manager.yaml
+++ b/internal-services/manager/manager.yaml
@@ -59,7 +59,7 @@ spec:
             - --leader-elect
             - --remote-cluster-config-file
             - /mnt/internal-services/remote-client-config/kubeconfig
-          image: quay.io/konflux-ci/internal-services:6edb83adc79ac8a01f7acf8f2526e78aff900a2c
+          image: quay.io/konflux-ci/internal-services:1f6e470ab440cea906daca1d1634dee1cfcca415
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/production/manager-prod-p01.yaml
+++ b/internal-services/manager/production/manager-prod-p01.yaml
@@ -61,7 +61,7 @@ spec:
             - /mnt/internal-services/remote-client-config/kubeconfig
             - --leader-election-id
             - "prod-p01"
-          image: quay.io/redhat-appstudio/internal-services:f4d159ed019cc8261efc87d17c783f575e3d772b
+          image: quay.io/konflux-ci/internal-services:1f6e470ab440cea906daca1d1634dee1cfcca415
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/production/manager-prod-p02.yaml
+++ b/internal-services/manager/production/manager-prod-p02.yaml
@@ -61,7 +61,7 @@ spec:
             - /mnt/internal-services/remote-client-config/kubeconfig
             - --leader-election-id
             - "prod-p02"
-          image: quay.io/redhat-appstudio/internal-services:f4d159ed019cc8261efc87d17c783f575e3d772b
+          image: quay.io/konflux-ci/internal-services:1f6e470ab440cea906daca1d1634dee1cfcca415
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/production/manager-prod-rh01.yaml
+++ b/internal-services/manager/production/manager-prod-rh01.yaml
@@ -59,7 +59,7 @@ spec:
             - --leader-elect
             - --remote-cluster-config-file
             - /mnt/internal-services/remote-client-config/kubeconfig
-          image: quay.io/redhat-appstudio/internal-services:f4d159ed019cc8261efc87d17c783f575e3d772b
+          image: quay.io/konflux-ci/internal-services:1f6e470ab440cea906daca1d1634dee1cfcca415
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/staging/manager-staging-p01.yaml
+++ b/internal-services/manager/staging/manager-staging-p01.yaml
@@ -61,7 +61,7 @@ spec:
             - /mnt/internal-services/remote-client-config/kubeconfig
             - --leader-election-id
             - "staging-p01"
-          image: quay.io/redhat-appstudio/internal-services:f4d159ed019cc8261efc87d17c783f575e3d772b
+          image: quay.io/konflux-ci/internal-services:1f6e470ab440cea906daca1d1634dee1cfcca415
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/rbac/service_account.yaml
+++ b/internal-services/rbac/service_account.yaml
@@ -10,3 +10,11 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: stonesoup-int-srvc
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-service-account
+  namespace: stonesoup-int-srvc
+secrets:
+- name: redhat-workloads-token


### PR DESCRIPTION
This bumps all the resources to be in sync for what is in the main branch for passing service accounts to pipelineRuns and adding the pulp pipeline and task.