### PR TITLE
fix: manually create docker config for pulp

### DIFF
--- a/internal-services/catalog/pulp-push-disk-images-task.yaml
+++ b/internal-services/catalog/pulp-push-disk-images-task.yaml
@@ -83,6 +83,11 @@ spec:
             secretKeyRef:
               name: $(params.udcacheSecret)
               key: key
+        - name: DOCKER_CONFIG_JSON
+          valueFrom:
+            secretKeyRef:
+              name: redhat-workloads-token
+              key: .dockerconfigjson
         - name: "SNAPSHOT_JSON"
           value: "$(params.snapshot_json)"
       script: |
@@ -121,6 +126,7 @@ spec:
         export EXODUS_GW_URL="$EXODUS_URL"
         export EXODUS_PULP_HOOK_ENABLED=True
         export EXODUS_GW_TIMEOUT=7200
+        mkdir ~/.docker
 
         set +x
         echo "$EXODUS_CERT" > "$EXODUS_GW_CERT"
@@ -129,6 +135,7 @@ spec:
         echo "$PULP_KEY" > "$PULP_KEY_FILE"
         echo "$UDC_CERT" > "$UDCACHE_CERT"
         echo "$UDC_KEY" > "$UDCACHE_KEY"
+        echo "$DOCKER_CONFIG_JSON" > ~/.docker/config.json
         set -x
 
         DISK_IMAGE_DIR="$(mktemp -d)"


### PR DESCRIPTION
This commit modifies the pulp-push-to-cdn-task to manually create the ~/.docker/config.json file instead of relying on tekton to do it via volume mounts as changing tekton config flags will make tekton no longer add the volume mount. So, let's not depend on it.