### PR TITLE
fix: add -p to mkdir in pulp push task

### DIFF
--- a/internal-services/catalog/pulp-push-disk-images-task.yaml
+++ b/internal-services/catalog/pulp-push-disk-images-task.yaml
@@ -126,7 +126,7 @@ spec:
         export EXODUS_GW_URL="$EXODUS_URL"
         export EXODUS_PULP_HOOK_ENABLED=True
         export EXODUS_GW_TIMEOUT=7200
-        mkdir ~/.docker
+        mkdir -p ~/.docker
 
         set +x
         echo "$EXODUS_CERT" > "$EXODUS_GW_CERT"


### PR DESCRIPTION
The task should not fail if the directory already exists.