### PR TITLE
fix(RELEASE-1108): cannot use global var in thread

### DIFF
--- a/internal-services/catalog/pulp-push-disk-images-task.yaml
+++ b/internal-services/catalog/pulp-push-disk-images-task.yaml
@@ -192,9 +192,6 @@ spec:
                 mv "$SOURCE" "${DESTINATION_FILE}" || echo "didn't find mapped file: ${SOURCE}"
             done
 
-            # we have a destination now. let's note this for CGW
-            CGW_DESTINATIONS+=("${DESTINATION}")
-
         }
 
         process_component_for_developer_portal() { # Expected argument are [component json], [content_directory]
@@ -216,7 +213,7 @@ spec:
 
         RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
         NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
-        CGW_DESTINATIONS=()
+
         # Process each component in parallel
         for ((i = 0; i < NUM_COMPONENTS; i++)) ; do
             COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
@@ -250,10 +247,18 @@ spec:
           --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" \
           2> "$STDERR_FILE"
 
+        relative_paths=$(echo "$STAGED_JSON" | jq -erc .payload.files[].relative_path)
+        component_destinations=()
+        for path in $relative_paths:
+        do
+          parent_dir=$(dirname "$path")
+          component_destinations+=("${DISK_IMAGE_DIR}/$parent_dir")
+        done
+
         ## Process Files for Developer Portal / CGW
         ##
         NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
         for ((i = 0; i < NUM_COMPONENTS; i++)) ; do
             COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
-            process_component_for_developer_portal "$COMPONENT" "${CGW_DESTINATIONS[$i]}" 2> "$STDERR_FILE"
+            process_component_for_developer_portal "$COMPONENT" "${component_destinations[$i]}" 2> "$STDERR_FILE"
         done


### PR DESCRIPTION
- since process_component is run in a thread, we cannot use global var to collect DESTINATIONS
- scrape the destinations from the staged JSON