### PR TITLE
fix: indexImageDigests should exist in all cases

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -214,8 +214,11 @@ spec:
               key: url
       script: |
         #!/usr/bin/env bash
-        TASKRUN="/tmp/$$.sh"
+        set -x
 
+        echo "" | tee $(results.iibLog.path)
+
+        TASKRUN="/tmp/$$.sh"
         cat > ${TASKRUN} <<SH
         #!/usr/bin/env bash
         #
@@ -230,10 +233,10 @@ spec:
             # remove the history as it breaks the results build up
             jq -r 'del(.state_history)' <<< \${build_info} | jq -c . > $(results.jsonBuildInfo.path)
             url=\$(jq -r ".logs.url" <<< \${build_info})
-            echo IIB log url is: "\${url}" > \$(results.iibLog.path)
-            echo Printing last 1,000 characters from the log >> \$(results.iibLog.path)
+            echo IIB log url is: "\${url}" > $(results.iibLog.path)
+            echo Printing last 1,000 characters from the log >> $(results.iibLog.path)
             # Tekton results max out at 4096 chars so we only take last 1000 from the log
-            /usr/bin/curl -s "\${url}" | tail -c 1000 >> \$(results.iibLog.path)
+            /usr/bin/curl -s "\${url}" | tail -c 1000 >> $(results.iibLog.path)
             case \${state} in
               "complete") break ;;
               "failed") break ;;
@@ -253,13 +256,12 @@ spec:
         timeout $(params.buildTimeoutSeconds) ${TASKRUN}
         BUILDEXIT=$?
 
-        # the result should exist in both cases
-        echo -n "" > "$(results.indexImageDigests.path)"
+        # these results should always exist.
+        echo "$BUILDEXIT" | tee $(results.exitCode.path)
+        echo -n "" | tee $(results.indexImageDigests.path)
 
         # it should continue only if the IIB build status is complete
         if [ ${BUILDEXIT} -eq 0 ]; then
-            echo -n 0 > "$(results.exitCode.path)"
-
             # get the manifest digests
             indexImageCopy=`cat $(results.jsonBuildInfo.path) | jq -cr .internal_index_image_copy`
             # Use this to obtain the manifest digests for each arch in manifest list
@@ -273,14 +275,13 @@ spec:
             echo -n $indexImageDigests > $(results.indexImageDigests.path)
             if [ -z "${indexImageDigests}" ] ; then
               echo "Index image produced is not multi-arch with a manifest list"
-              echo -n 1 > "$(results.exitCode.path)"
+              echo -n 1 |tee $(results.exitCode.path)
             fi
         else
             if [ ${BUILDEXIT} -eq 124 ]; then
                 echo "Timeout while waiting for the build to finish"
-                echo "Build timeout" > $(results.buildState.path)
+                echo "Build timeout" > "$(results.buildState.path)"
             fi
-            echo -n "$BUILDEXIT" > "$(results.exitCode.path)"
         fi
         exit 0
   volumes:

--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: t-add-fbc-fragment-to-index-image
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -62,6 +62,10 @@ spec:
       description: Set the genericResult if FBC Fragment is Opt-In and should be published
     - name: indexImageDigests
       description: The digests for each arch for the manifest list of the index image
+    - name: iibLog
+      description: The log from the IIB request
+    - name: exitCode
+      description: The exit code from the task
   steps:
     - name: s-add-fbc-fragment-to-index-image
       image: >-
@@ -225,6 +229,11 @@ spec:
             state=\$(jq -r ".state" <<< \${build_info})
             # remove the history as it breaks the results build up
             jq -r 'del(.state_history)' <<< \${build_info} | jq -c . > $(results.jsonBuildInfo.path)
+            url=\$(jq -r ".logs.url" <<< \${build_info})
+            echo IIB log url is: "\${url}" > \$(results.iibLog.path)
+            echo Printing last 1,000 characters from the log >> \$(results.iibLog.path)
+            # Tekton results max out at 4096 chars so we only take last 1000 from the log
+            /usr/bin/curl -s "\${url}" | tail -c 1000 >> \$(results.iibLog.path)
             case \${state} in
               "complete") break ;;
               "failed") break ;;
@@ -246,6 +255,7 @@ spec:
 
         # it should continue only if the IIB build status is complete
         if [ ${BUILDEXIT} -eq 0 ]; then
+            echo -n 0 > "$(results.exitCode.path)"
 
             # get the manifest digests
             indexImageCopy=`cat $(results.jsonBuildInfo.path) | jq -cr .internal_index_image_copy`
@@ -260,17 +270,17 @@ spec:
             echo -n $indexImageDigests > $(results.indexImageDigests.path)
             if [ -z "${indexImageDigests}" ] ; then
               echo "Index image produced is not multi-arch with a manifest list"
-              exit 1
+              echo -n 1 > "$(results.exitCode.path)"
             fi
         else
             if [ ${BUILDEXIT} -eq 124 ]; then
                 echo "Timeout while waiting for the build to finish"
                 echo "Build timeout" < $(results.buildState.path)
-                exit $BUILDEXIT
-            else
-              exit $BUILDEXIT
             fi
+            echo -n "" > "$(results.indexImageDigests.path)"
+            echo -n "$BUILDEXIT" > "$(results.exitCode.path)"
         fi
+        exit 0
   volumes:
     - name: service-account-secret
       secret:

--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -253,6 +253,9 @@ spec:
         timeout $(params.buildTimeoutSeconds) ${TASKRUN}
         BUILDEXIT=$?
 
+        # the result should exist in both cases
+        echo -n "" > "$(results.indexImageDigests.path)"
+
         # it should continue only if the IIB build status is complete
         if [ ${BUILDEXIT} -eq 0 ]; then
             echo -n 0 > "$(results.exitCode.path)"
@@ -275,9 +278,8 @@ spec:
         else
             if [ ${BUILDEXIT} -eq 124 ]; then
                 echo "Timeout while waiting for the build to finish"
-                echo "Build timeout" < $(results.buildState.path)
+                echo "Build timeout" > $(results.buildState.path)
             fi
-            echo -n "" > "$(results.indexImageDigests.path)"
             echo -n "$BUILDEXIT" > "$(results.exitCode.path)"
         fi
         exit 0

--- a/internal-services/catalog/iib-pipeline.yaml
+++ b/internal-services/catalog/iib-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: iib
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: fbc
@@ -92,3 +92,7 @@ spec:
       value: $(tasks.t-add-fbc-fragment-to-index-image.results.genericResult)
     - name: indexImageDigests
       value: $(tasks.t-add-fbc-fragment-to-index-image.results.indexImageDigests)
+    - name: iibLog
+      value: $(tasks.t-add-fbc-fragment-to-index-image.results.iibLog)
+    - name: exitCode
+      value: $(tasks.t-add-fbc-fragment-to-index-image.results.exitCode)


### PR DESCRIPTION
this commit fixes the indexImageDigests result creation for all cases due to that in case of success, its creation was conditioned to a non-empty parameter in the json response