### PR TITLE
fix(KFLUXBUGS-1278): make iib errors available to users

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -1,10 +1,10 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: t-add-fbc-fragment-to-index-image
   labels:
-    app.kubernetes.io/version: "0.2.0"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -62,6 +62,10 @@ spec:
       description: Set the genericResult if FBC Fragment is Opt-In and should be published
     - name: indexImageDigests
       description: The digests for each arch for the manifest list of the index image
+    - name: iibLog
+      description: The link to the log from the IIB request
+    - name: exitCode
+      description: The exit code from the task
   steps:
     - name: s-add-fbc-fragment-to-index-image
       image: >-
@@ -210,42 +214,45 @@ spec:
               key: url
       script: |
         #!/usr/bin/env bash
-        TASKRUN="/tmp/$$.sh"
+        # shellcheck disable=SC2317 # shellcheck calls all the commands in the function unreachable
+        # because it is called via `timeout`
+        set -x
 
-        cat > ${TASKRUN} <<SH
-        #!/usr/bin/env bash
-        #
-        build_id=`jq -r ".id" $(results.jsonBuildInfo.path)`
-        state=""
-        while true; do
-            #
-            # fetching build information.
-            build_info=\$(/usr/bin/curl -s "\${IIB_SERVICE_URL}/builds/\${build_id}")
-            # get state from the build information.
-            state=\$(jq -r ".state" <<< \${build_info})
-            # remove the history as it breaks the results build up
-            jq -r 'del(.state_history)' <<< \${build_info} | jq -c . > $(results.jsonBuildInfo.path)
-            case \${state} in
-              "complete") break ;;
-              "failed") break ;;
-              *) echo -en "."; sleep 30; continue ;;
-            esac
-        done
-        echo
-        jq -cr '{ "state": .state, "state_reason": .state_reason }' $(results.jsonBuildInfo.path) | jq -Rc \
-        | tee $(results.buildState.path)
-        test \${state} = "complete" && exit 0 || exit 1
-        SH
+        watch_build_state() {
+            build_id="$(jq -r ".id" "$(results.jsonBuildInfo.path)")"
+            state=""
+            while true; do
+                #
+                # fetching build information.
+                build_info=$(curl -s "${IIB_SERVICE_URL}/builds/${build_id}")
+                # get state from the build information.
+                state="$(jq -r ".state" <<< "${build_info}")"
+                # remove the history as it breaks the results build up
+                jq -r 'del(.state_history)' <<< "${build_info}" | jq -c . > "$(results.jsonBuildInfo.path)"
+                url="$(jq -r ".logs.url" <<< "${build_info}")"
+                echo IIB log url is: "${url}" > "$(results.iibLog.path)"
+                case ${state} in
+                  "complete") break ;;
+                  "failed") break ;;
+                  *) echo -en "."; sleep 30; continue ;;
+                esac
+            done
+            echo
+            jq -cr '{ "state": .state, "state_reason": .state_reason }' "$(results.jsonBuildInfo.path)" | jq -Rc \
+            | tee "$(results.buildState.path)"
+            test "${state}" = "complete" && exit 0 || exit 1
+        }
 
-        chmod +x ${TASKRUN}
         echo -en "waiting for build state to exit..."
         # adding timeout here due to the Task timeout not accepting $(params.buildTimeoutSeconds)
         # as parameter.
-        timeout $(params.buildTimeoutSeconds) ${TASKRUN}
+        export -f watch_build_state
+        timeout "$(params.buildTimeoutSeconds)" bash -c watch_build_state
         BUILDEXIT=$?
 
         # it should continue only if the IIB build status is complete
         if [ ${BUILDEXIT} -eq 0 ]; then
+            echo -n 0 > "$(results.exitCode.path)"
 
             # get the manifest digests
             indexImageCopy=`cat $(results.jsonBuildInfo.path) | jq -cr .internal_index_image_copy`
@@ -260,17 +267,21 @@ spec:
             echo -n $indexImageDigests > $(results.indexImageDigests.path)
             if [ -z "${indexImageDigests}" ] ; then
               echo "Index image produced is not multi-arch with a manifest list"
-              exit 1
+              echo -n 1 > "$(results.exitCode.path)"
             fi
         else
             if [ ${BUILDEXIT} -eq 124 ]; then
                 echo "Timeout while waiting for the build to finish"
                 echo "Build timeout" < $(results.buildState.path)
-                exit $BUILDEXIT
-            else
-              exit $BUILDEXIT
             fi
+            echo -n "" > "$(results.indexImageDigests.path)"
+            echo -n "$BUILDEXIT" > "$(results.exitCode.path)"
         fi
+        # We don't put the log in a result because tekton results are too limited for what we can put
+        # to be useful, but still print it for debugging
+        curl -s "$(awk '{print $NF}' < "$(results.iibLog.path)")"
+
+        exit 0
   volumes:
     - name: service-account-secret
       secret:

--- a/internal-services/catalog/iib-pipeline.yaml
+++ b/internal-services/catalog/iib-pipeline.yaml
@@ -1,10 +1,10 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: iib
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: fbc
@@ -92,3 +92,7 @@ spec:
       value: $(tasks.t-add-fbc-fragment-to-index-image.results.genericResult)
     - name: indexImageDigests
       value: $(tasks.t-add-fbc-fragment-to-index-image.results.indexImageDigests)
+    - name: iibLog
+      value: $(tasks.t-add-fbc-fragment-to-index-image.results.iibLog)
+    - name: exitCode
+      value: $(tasks.t-add-fbc-fragment-to-index-image.results.exitCode)


### PR DESCRIPTION
This commit exposes the iib error log if one occurred in the iib operation and bubbles it up to the pipelineRun as a result. It also changes the iib-add-fbc-fragment-to-index-image task to never fail.