### PR TITLE
fix: increase timeout for push-disk-images IR

### DIFF
--- a/internal-services/catalog/pulp-push-disk-images-pipeline.yaml
+++ b/internal-services/catalog/pulp-push-disk-images-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-disk-images
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
 spec:
@@ -35,7 +35,7 @@ spec:
       description: Env specific secret containing the content gateway credentials
   tasks:
     - name: pulp-push-disk-images
-      timeout: "2h00m0s"
+      timeout: "4h00m0s"
       taskRef:
         name: pulp-push-disk-images
       params:


### PR DESCRIPTION
The disk images for RHEL AI are very big and
we repeatedly saw timeouts. We will make it
customizable here:
https://issues.redhat.com/browse/RELEASE-1143

But for now, let's increase the value.