### PR TITLE
fix(KFLUXBUGS-1614): fbc pipeline should stop passing binaryImage to iib

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: t-add-fbc-fragment-to-index-image
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.3.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -19,11 +19,6 @@ spec:
       type: string
       description: ->
         Index image (catalog of catalogs) the FBC fragment will be added to
-    - name: binaryImage
-      type: string
-      description: ->
-        OCP binary image to be baked into the index image. This image is used to
-        serve the index image content on customer clusters.
     - name: buildTags
       type: string
       description: ->
@@ -178,7 +173,6 @@ spec:
         {
           "fbc_fragment": "$(params.fbcFragment)",
           "from_index": "$(params.fromIndex)",
-          "binary_image": "$(params.binaryImage)",
           "build_tags": `echo $(params.buildTags)`,
           "add_arches": `echo $(params.addArches)`,
           "overwrite_from_index": ${fbcOptIn},
@@ -188,7 +182,6 @@ spec:
 
         # filtering out empty params
         jq -r '
-          if .binary_image == "" then del(.binary_image) else . end |
           if .overwrite_from_index == false then del(( .overwrite_from_index, .overwrite_from_index_token)) else . end |
           if(.add_arches | length) == 0 then del(.add_arches) else . end |
           if(.build_tags | length) == 0 then del(.build_tags) else . end' ${json_raw_input} > ${json_input}

--- a/internal-services/catalog/iib-pipeline.yaml
+++ b/internal-services/catalog/iib-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: iib
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: fbc
@@ -12,10 +12,6 @@ spec:
   description: >-
     Tekton pipeline to interact with IIB service for File Based Catalogs
   params:
-    - name: binaryImage
-      type: string
-      default: ""
-      description: The Snapshot in JSON format
     - name: iibServiceConfigSecret
       type: string
       default: iib-services-config
@@ -61,8 +57,6 @@ spec:
       taskRef:
         name: t-add-fbc-fragment-to-index-image
       params:
-        - name: binaryImage
-          value: $(params.binaryImage)
         - name: iibServiceConfigSecret
           value: $(params.iibServiceConfigSecret)
         - name: iibOverwriteFromIndexCredential


### PR DESCRIPTION
this commit removes the passing of the binaryImage parameter to IIB, so it can auto resolve it.