### PR TITLE
feat(RELEASE-1102): remove unused data.fbc parameters from fbc

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -31,12 +31,6 @@ spec:
       type: string
       default: "300"
       description: Timeout seconds to receive the build state
-    - name: iibServiceConfigSecret
-      type: string
-      description: Secret with IIB service config to be used
-    - name: iibOverwriteFromIndexCredential
-      type: string
-      description: Secret with overwrite FromIndex credentials to be passed to IIB
     - name: iibServiceAccountSecret
       type: string
       description: Secret with IIB credentials to be used
@@ -69,17 +63,17 @@ spec:
         - name: IIB_SERVICE_URL
           valueFrom:
             secretKeyRef:
-              name: $(params.iibServiceConfigSecret)
+              name: iib-services-config
               key: url
         - name: IIB_OVERWRITE_FROM_INDEX_USERNAME
           valueFrom:
             secretKeyRef:
-              name: $(params.iibOverwriteFromIndexCredential)
+              name: iib-overwrite-fromimage-credentials
               key: username
         - name: IIB_OVERWRITE_FROM_INDEX_TOKEN
           valueFrom:
             secretKeyRef:
-              name: $(params.iibOverwriteFromIndexCredential)
+              name: iib-overwrite-fromimage-credentials
               key: token
         - name: KRB5_CONF_CONTENT
           valueFrom:

--- a/internal-services/catalog/iib-pipeline.yaml
+++ b/internal-services/catalog/iib-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: iib
   labels:
-    app.kubernetes.io/version: "0.4.0"
+    app.kubernetes.io/version: "0.5.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: fbc
@@ -12,14 +12,6 @@ spec:
   description: >-
     Tekton pipeline to interact with IIB service for File Based Catalogs
   params:
-    - name: iibServiceConfigSecret
-      type: string
-      default: iib-services-config
-      description: Secret containing IIB service Config
-    - name: iibOverwriteFromIndexCredential
-      type: string
-      default: iib-overwrite-fromimage-credentials
-      description: Secret with overwrite FromImage credentials to be passed to IIB
     - name: iibServiceAccountSecret
       type: string
       description: Secret containing the credentials for IIB service
@@ -57,10 +49,6 @@ spec:
       taskRef:
         name: t-add-fbc-fragment-to-index-image
       params:
-        - name: iibServiceConfigSecret
-          value: $(params.iibServiceConfigSecret)
-        - name: iibOverwriteFromIndexCredential
-          value: $(params.iibOverwriteFromIndexCredential)
         - name: iibServiceAccountSecret
           value: $(params.iibServiceAccountSecret)
         - name: fbcFragment


### PR DESCRIPTION
this commit removes references of unused or unecessary parameters in FBC Release Pipeline and tasks,
namely: iibServiceConfigSecret, iibServiceAccountSecret and iibOverwriteFromIndexCredential.