### PR TITLE
fix: enable more logging for kinit

### DIFF
--- a/internal-services/catalog/check-embargoed-cves-task.yaml
+++ b/internal-services/catalog/check-embargoed-cves-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: check-embargoed-cves-task
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -69,6 +69,7 @@ spec:
           # workaround kinit: Invalid UID in persistent keyring name while getting default ccache
           export KRB5CCNAME=`mktemp`
           export KRB5_CONFIG=`mktemp`
+          export KRB5_TRACE=/dev/stderr
           sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
           kinit ${SERVICE_ACCOUNT_NAME} -k -t /tmp/keytab
 

--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "0.9"
+    app.kubernetes.io/version: "0.9.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -131,6 +131,7 @@ spec:
           export KRB5CCNAME=`mktemp`
           # see https://stackoverflow.com/a/12308187
           export KRB5_CONFIG=`mktemp`
+          export KRB5_TRACE=/dev/stderr
           sed '/\[libdefaults\]/a\    dns_canonicalize_hostname = false' /etc/krb5.conf > "${KRB5_CONFIG}"
           kinit ${SERVICE_ACCOUNT_NAME} -k -t /tmp/keytab
           ID=$(curl --retry 3 --negotiate -u : ${ERRATA_API}/advisory/reserve_live_id -XPOST | jq -r '.live_id')

--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: t-add-fbc-fragment-to-index-image
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.2.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -117,6 +117,7 @@ spec:
         KRB5_TEMP_CONF=$(mktemp)
         echo "${KRB5_CONF_CONTENT}" > "${KRB5_TEMP_CONF}"
         export KRB5_CONFIG="${KRB5_TEMP_CONF}"
+        export KRB5_TRACE=/dev/stderr
 
         /usr/bin/kinit -V $(cat /mnt/service-account-secret/principal) -k -t /tmp/keytab
 


### PR DESCRIPTION
Recently, we had issues when doing kinit, it would say:

kinit: Generic error (see e-text) while
getting initial credentials

It was suggested to us to enable
kerberos trace logging so that next time
we have more details to report.

This is the same as https://github.com/hacbs-release/app-interface-deployments/pull/190 but for prod