### PR TITLE
fix: use virtual environment for gitlint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,10 +46,22 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Install gitlint into container
-        run: python -m pip install gitlint
+      # Set up Python and create virtual environment
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Create virtual environment
+        run: python3 -m venv venv
+
+      - name: Activate virtual environment and install gitlint
+        run: |
+          source venv/bin/activate
+          pip install gitlint
+
       - name: Run gitlint check
-        run: gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
+        run: venv/bin/gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
   checkton:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR fixes the `gitlint` installation issue in the CI pipeline caused by PEP 668. A virtual environment is now used to install `gitlint`, avoiding conflicts with the system-managed Python environment.
See [comment](https://github.com/hacbs-release/app-interface-deployments/pull/196#issuecomment-2414224881) for more details.