### PR TITLE
fix: empty variable should not keep quotes (#201)

### DIFF
--- a/internal-services/catalog/publish-index-image-task.yaml
+++ b/internal-services/catalog/publish-index-image-task.yaml
@@ -54,14 +54,14 @@ spec:
 
         # do not authenticate if the source is redhat's "registry-proxy" which is unauthenticated.
         if [[ ! "$(params.sourceIndex)" =~ ^registry-proxy(\-stage)?.engineering.redhat.com ]]; then
-            AUTH_PARAM="--src-creds ${SOURCE_INDEX_CREDENTIAL}"
+            AUTH_PARAM=("--src-creds" "${SOURCE_INDEX_CREDENTIAL}")
         fi
 
         (skopeo copy \
         --all \
         --preserve-digests \
         --retry-times "$(params.retries)" \
-        --src-tls-verify=false "${AUTH_PARAM}" \
+        --src-tls-verify=false "${AUTH_PARAM[@]}" \
         "docker://$(params.sourceIndex)" \
         --dest-creds "${TARGET_INDEX_CREDENTIAL}" \
         "docker://$(params.targetIndex)" && \


### PR DESCRIPTION
the PR fixes the bug caused by when an empty AUTH_PARAM is passed the quotes are preserved, causing skopeo to complain on the unknown parameter.