### PR TITLE
fix(RELEASE-1271): use bundle resolver in signing pipeline

### DIFF
--- a/internal-services/catalog/sign-image-pipeline.yaml
+++ b/internal-services/catalog/sign-image-pipeline.yaml
@@ -41,9 +41,16 @@ spec:
 
     - name: request-signature
       taskRef:
-        name: request-signature
-        bundle:
-          quay.io/redhat-isv/tkn-signing-bundle@sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d
+        resolver: bundle
+        params:
+          - name: bundle
+            value: >-
+              quay.io/redhat-isv/tkn-signing-bundle
+              @sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d
+          - name: name
+            value: request-signature
+          - name: kind
+            value: task
       runAfter:
         - set-env
       params:
@@ -80,9 +87,16 @@ spec:
 
     - name: upload-signature
       taskRef:
-        name: upload-signature
-        bundle:
-          quay.io/redhat-isv/tkn-signing-bundle@sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d
+        resolver: bundle
+        params:
+          - name: bundle
+            value: >-
+              quay.io/redhat-isv/tkn-signing-bundle
+              @sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d
+          - name: name
+            value: upload-signature
+          - name: kind
+            value: task
       runAfter:
         - request-signature
       params:


### PR DESCRIPTION
The old bundle reference was deprecated in Tekton 1.15 and removed in 1.16 and app-sre just deployed 1.16 which broke signing in Konflux. Updating to bundle resolver format should fix it.

Note that this pipeline definition is still not really used, we use the hacbs-signing-pipeline from a different repo, but this is a copy we have and it's useful
for testing.