### PR TITLE
fix: spliting of long string

### DIFF
--- a/internal-services/catalog/sign-image-pipeline.yaml
+++ b/internal-services/catalog/sign-image-pipeline.yaml
@@ -44,9 +44,8 @@ spec:
         resolver: bundle
         params:
           - name: bundle
-            value: >-
-              quay.io/redhat-isv/tkn-signing-bundle
-              @sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d
+            value: "quay.io/redhat-isv/tkn-signing-bundle@\
+sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d"
           - name: name
             value: request-signature
           - name: kind
@@ -90,9 +89,8 @@ spec:
         resolver: bundle
         params:
           - name: bundle
-            value: >-
-              quay.io/redhat-isv/tkn-signing-bundle
-              @sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d
+            value: "quay.io/redhat-isv/tkn-signing-bundle@\
+sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d"
           - name: name
             value: upload-signature
           - name: kind


### PR DESCRIPTION
The lines were too long and yamllint didn't like it. I tried to split them using `>-` but that didn't work - it added an extra space in between. This should work.

I tested this using a test yaml:
```
---
something:
  longstring: "my long\
string"
```
And then reading it with `yq` and it was able to render it correctly:
```
---
something:
  longstring: "my longstring"
```