### PR TITLE
fix(RELEASE-1271): correct name for bundles resolver

### DIFF
--- a/internal-services/catalog/sign-image-pipeline.yaml
+++ b/internal-services/catalog/sign-image-pipeline.yaml
@@ -41,7 +41,7 @@ spec:
 
     - name: request-signature
       taskRef:
-        resolver: bundle
+        resolver: bundles
         params:
           - name: bundle
             value: "quay.io/redhat-isv/tkn-signing-bundle@\
@@ -86,7 +86,7 @@ sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d"
 
     - name: upload-signature
       taskRef:
-        resolver: bundle
+        resolver: bundles
         params:
           - name: bundle
             value: "quay.io/redhat-isv/tkn-signing-bundle@\


### PR DESCRIPTION
The correct name of the resolver is actually bundles, not bundle.

Note: This pipeline isn't really used, it's a copy of the hacbs-signing-pipeline. It's used for testing only.

See:
https://github.com/konflux-ci/release-service-catalog/pull/655