### PR TITLE
feat(RELEASE-1223): validate created advisory against schema

### DIFF
--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "0.9.1"
+    app.kubernetes.io/version: "0.10.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -41,7 +41,7 @@ spec:
       description: The advisory url if the task succeeds, empty string otherwise
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
       env:
         - name: GITLAB_HOST
           valueFrom:
@@ -156,6 +156,9 @@ spec:
           # Create advisory file
           /home/utils/apply_template.py -o $ADVISORY_FILEPATH --data "$DATA" \
             --template /home/templates/advisory.yaml.jinja
+
+          # Ensure the created advisory file passes the advisory schema
+          check-jsonschema --schemafile schema/advisory.json "$ADVISORY_FILEPATH"
 
           git add ${ADVISORY_FILEPATH}
           git commit -m "[Konflux Release] new advisory for $(params.application)"


### PR DESCRIPTION
This commit modifies the create-advisory-task to validate the generated advisory.yaml against the advisory schema before pushing it to the repo.