### PR TITLE
fix: revert to using redhate2etesting key

### DIFF
--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
@@ -10,8 +10,8 @@ metadata:
   name: "hacbs-signing-pipeline-config-staging-redhatbeta2"
 data:
   PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
-  SIG_KEY_ID: "4096R/F21541EB SHA-256"
-  SIG_KEY_NAME: "beta2"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"

--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatrelease2.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatrelease2.yaml
@@ -10,8 +10,8 @@ metadata:
   name: "hacbs-signing-pipeline-config-staging-redhatrelease2"
 data:
   PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
-  SIG_KEY_ID: "4096R/FD431D51 SHA-256"
-  SIG_KEY_NAME: "redhatrelease2"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"


### PR DESCRIPTION
- since we are using stage services for releasing stage content, we need to ensure that we are using a key that can sign on stage RADAS.