### PR TITLE
fix(KFLUXBUGS-1896): do not hardcode errata secret name for advisories

### DIFF
--- a/internal-services/catalog/create-advisory-pipeline.yaml
+++ b/internal-services/catalog/create-advisory-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: create-advisory
   labels:
-    app.kubernetes.io/version: "0.4"
+    app.kubernetes.io/version: "0.5"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: advisory
@@ -31,6 +31,9 @@ spec:
     - name: advisory_secret_name
       type: string
       description: The name of the secret that contains the advisory creation metadata
+    - name: errata_secret_name
+      type: string
+      description: The name of the secret that contains the errata service account metadata
   tasks:
     - name: create-advisory-task
       taskRef:
@@ -46,6 +49,8 @@ spec:
           value: $(params.config_map_name)
         - name: advisory_secret_name
           value: $(params.advisory_secret_name)
+        - name: errata_secret_name
+          value: $(params.errata_secret_name)
   results:
     - name: result
       value: $(tasks.create-advisory-task.results.result)

--- a/internal-services/catalog/create-advisory-task.yaml
+++ b/internal-services/catalog/create-advisory-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: create-advisory-task
   labels:
-    app.kubernetes.io/version: "0.10.0"
+    app.kubernetes.io/version: "0.11.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -34,6 +34,9 @@ spec:
     - name: advisory_secret_name
       type: string
       description: The name of the secret that contains the advisory creation metadata
+    - name: errata_secret_name
+      type: string
+      description: The name of the secret that contains the errata service account metadata
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -74,17 +77,17 @@ spec:
         - name: ERRATA_API
           valueFrom:
             secretKeyRef:
-              name: errata-service-account
+              name: $(params.errata_secret_name)
               key: errata_api
         - name: SERVICE_ACCOUNT_NAME
           valueFrom:
             secretKeyRef:
-              name: errata-service-account
+              name: $(params.errata_secret_name)
               key: name
         - name: SERVICE_ACCOUNT_KEYTAB
           valueFrom:
             secretKeyRef:
-              name: errata-service-account
+              name: $(params.errata_secret_name)
               key: base64_keytab
         - name: "ADVISORY_JSON"
           value: "$(params.advisory_json)"
@@ -109,7 +112,9 @@ spec:
 
           REPO_BRANCH=main
           ADVISORY_URL=""
-          cd /tmp # Workaround fatal: could not create work tree dir Permission denied
+
+          # Switch to /tmp to avoid filesystem permission issues
+          cd /tmp
 
           # loading git and gitlab functions
           . /home/utils/gitlab-functions


### PR DESCRIPTION
This commit changes the create-advisory task and pipeline to accept a parameter for the errata secret instead of hardcoding it. This allows us to differentiate stage and prod.