### PR TITLE
fix(RELEASE-1099): lint issue on iib-add-fbc-fragment-to-index-image

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: t-add-fbc-fragment-to-index-image
   labels:
-    app.kubernetes.io/version: "0.3.2"
+    app.kubernetes.io/version: "0.3.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -82,30 +82,23 @@ spec:
               key: krb5.conf
       script: |
         #!/usr/bin/env bash
-        #
-        # all in line shellcheck disables will be handled in the PR below:
-        # https://github.com/hacbs-release/app-interface-deployments/pull/236
 
-        isfbcOptIn() {
+        isFBCOptIn() {
           TMPFILE=$(mktemp)
           PYXIS_URL="https://pyxis.engineering.redhat.com/v1"
 
-          # shellcheck disable=SC2162 # (info): read without -r will mangle backslashes.
-          IFS="/" read REGISTRY REPO IMAGE <<< "${1}"
-          # shellcheck disable=SC2162 # (info): read without -r will mangle backslashes.
-          IFS=":" read IMAGE TAG <<< "${IMAGE}"
+          IFS="/" read -r REGISTRY REPO IMAGE <<< "${1}"
+          IFS=":" read -r IMAGE TAG <<< "${IMAGE}"
 
           FETCH_URL="${PYXIS_URL}/repositories/registry/${REGISTRY}/repository/${REPO}/${IMAGE}/tag/${TAG}"
 
           # strips the last "/tag" in case $TAG is not set
           [ -z "${TAG}" ] && FETCH_URL=${FETCH_URL%/tag*}
 
-          # shellcheck disable=SC2086 # (info): Double quote to prevent globbing and word splitting.
-          curl --negotiate -u: "${FETCH_URL}" -o $TMPFILE
+          curl --negotiate -u: "${FETCH_URL}" -o "${TMPFILE}"
 
           # prints "false" in case .fbc_opt_in entry is missing
-          # shellcheck disable=SC2086 # (info): Double quote to prevent globbing and word splitting.
-          jq -e -r '.fbc_opt_in //false' $TMPFILE && rm -f $TMPFILE
+          jq -e -r '.fbc_opt_in //false' "${TMPFILE}" && rm -f "${TMPFILE}"
         }
 
         # checks if there is any previous build for the same fbc_fragment.
@@ -129,66 +122,48 @@ spec:
 
         echo "${KRB5_CONF_CONTENT}" > "${KRB5_TEMP_CONF}"
         export KRB5_CONFIG="${KRB5_TEMP_CONF}"
-
         export KRB5_TRACE=/dev/stderr
 
         /usr/bin/kinit -V "${KRB5_PRINCIPAL}" -k -t /tmp/keytab
 
         set -x
+        # check if this fbc fragment is opt-in
+        echo "Fetching the image bundle from $(params.fbcFragment)..."
+        PULL_SPEC_LIST=$(opm render "$(params.fbcFragment)" | jq -r \
+        'select(.schema == "olm.bundle") | "\(.image)" | split("@")[0]' |uniq)
+
+        fbcOptIn="true"
+        for PULL_SPEC in ${PULL_SPEC_LIST}; do
+            # make sure they query is done using the internal name instead of the public
+            PULL_SPEC="${PULL_SPEC//registry.redhat.io/registry.access.redhat.com}"
+            echo "Attempting to fetch from ${FETCH_URL} to check if fragment is \`fbc_opt_in==true\`..."
+            if [ "$(isFBCOptIn "${PULL_SPEC}")" = "false" ]; then
+              fbcOptIn="false"
+              break
+            fi
+        done
+        mustOverwriteFromIndexImage="${fbcOptIn}"
+        mustPublishIndexImage="${fbcOptIn}"
+        mustSignIndexImage="${fbcOptIn}"
+
         if [ "$(params.hotfix)" == "true" ]; then
             echo "Hotfix build"
-            fbcOptIn="false"
+            mustOverwriteFromIndexImage="false"
             mustSignIndexImage="true"
             mustPublishIndexImage="true"
         elif [ "$(params.stagedIndex)" == "true" ]; then
             echo "Staged Index build"
-            fbcOptIn="false"
+            mustOverwriteFromIndexImage="false"
             mustSignIndexImage="false"
             mustPublishIndexImage="false"
-        else
-            # check if this fbc fragment is opt-in
-            echo "Fetching the image bundle from $(params.fbcFragment)..."
-            PULL_SPEC_LIST=$(opm render "$(params.fbcFragment)" | jq -r \
-            'select(.schema == "olm.bundle") | "\(.image)" | split("@")[0]' |uniq)
-            for PULL_SPEC in ${PULL_SPEC_LIST}; do
-                # make sure they query is done using the internal name instead of the public
-                PULL_SPEC="${PULL_SPEC//registry.redhat.io/registry.access.redhat.com}"
-
-                echo "Attempting to fetch from ${FETCH_URL} to check if fragment is \`fbc_opt_in==true\`..."
-                # shellcheck disable=SC2207
-                #   (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).
-                # shellcheck disable=SC2006 # (style): Use \$(...) notation instead of legacy backticks `...`.
-                # shellcheck disable=SC2086 # (info): Double quote to prevent globbing and word splitting.
-                fbcOptIn+=(`isfbcOptIn ${PULL_SPEC}`)
-            done
-
-            # shellcheck disable=SC2207
-            #   (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).
-            # shellcheck disable=SC2068 # (error): Double quote array expansions to avoid re-splitting elements.
-            fbcOptIn=($(printf "%s\n" ${fbcOptIn[@]} |sort |uniq))
-
-            # shellcheck disable=SC2128 # (warning): Expanding an array without an index only gives the first element.
-            mustPublishIndexImage="${fbcOptIn}"
-            # shellcheck disable=SC2128 # (warning): Expanding an array without an index only gives the first element.
-            mustSignIndexImage="${fbcOptIn}"
-
-            # in case of more than one image all should have the same fbc_opt_in value
-            if [ "$(wc -w <<< "${fbcOptIn[@]}")" -ne 1 ]; then
-                fbcOptIn=("false")
-                mustSignIndexImage="false"
-                mustPublishIndexImage="false"
-            fi
         fi
 
-        # shellcheck disable=SC2128 # (warning): Expanding an array without an index only gives the first element.
         echo "Fragment has \`fbc_opt_in==${fbcOptIn}\`"
         echo "             \`mustPublishIndexImage==${mustPublishIndexImage}\`"
         echo "             \`mustSignIndexImage==${mustSignIndexImage}\`"
 
         # these results will be used by add-fbc-contribution to control
         # signing and publishing of the built fragment
-        # shellcheck disable=SC2128 # (warning): Expanding an array without an index only gives the first element.
-        # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
         jq -n -c \
            --arg fbc_opt_in "${fbcOptIn}" \
            --arg publish_index_image "${mustPublishIndexImage}" \
@@ -197,7 +172,7 @@ spec:
              "fbc_opt_in": $fbc_opt_in,
              "publish_index_image": $publish_index_image,
              "sign_index_image": $sign_index_image
-            } | tostring' | tee $(results.genericResult.path)
+            } | tostring' | tee "$(results.genericResult.path)"
 
         # if it finds a build which is completed or in progress, it should exit this step and jump to
         # the next step `s-wait-for-build-state` which will watch the build until it is completed.
@@ -213,17 +188,13 @@ spec:
         json_input=/tmp/$$.tmp
         json_raw_input=/tmp/$$_raw.tmp
 
-        # shellcheck disable=SC2006 # (style): Use $(...) notation instead of legacy backticks `...`.
-        # shellcheck disable=SC2128 # (warning): Expanding an array without an index only gives the first element.
-        # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
-        # shellcheck disable=SC2005 # (style): Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
         cat > $json_raw_input <<JSON
         {
           "fbc_fragment": "$(params.fbcFragment)",
           "from_index": "$(params.fromIndex)",
-          "build_tags": `echo $(params.buildTags)`,
-          "add_arches": `echo $(params.addArches)`,
-          "overwrite_from_index": ${fbcOptIn},
+          "build_tags": $(params.buildTags),
+          "add_arches": $(params.addArches),
+          "overwrite_from_index": ${mustOverwriteFromIndexImage},
           "overwrite_from_index_token": "${IIB_OVERWRITE_FROM_INDEX_USERNAME}:${IIB_OVERWRITE_FROM_INDEX_TOKEN}"
         }
         JSON
@@ -234,16 +205,13 @@ spec:
           if(.add_arches | length) == 0 then del(.add_arches) else . end |
           if(.build_tags | length) == 0 then del(.build_tags) else . end' ${json_raw_input} > ${json_input}
 
-        # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
-        echo "Calling IIB endpoint" > $(results.buildState.path)
+        echo "Calling IIB endpoint" > "$(results.buildState.path)"
         # adds image to the index.
-        # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
         /usr/bin/curl -u : --negotiate -s -X POST -H "Content-Type: application/json" -d@${json_input} --insecure \
-        "${IIB_SERVICE_URL}/builds/fbc-operations" |tee $(results.jsonBuildInfo.path)
+        "${IIB_SERVICE_URL}/builds/fbc-operations" |tee "$(results.jsonBuildInfo.path)"
 
         # checks if the previous call returned an error.
-        # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
-        ! jq -e -r ".error | select( . != null )" $(results.jsonBuildInfo.path)
+        ! jq -e -r ".error | select( . != null )" "$(results.jsonBuildInfo.path)"
       volumeMounts:
         - name: service-account-secret
           mountPath: /mnt/service-account-secret
@@ -259,7 +227,6 @@ spec:
       script: |
         #!/usr/bin/env bash
         # shellcheck disable=SC2317 # shellcheck calls all the commands in the function unreachable
-        # because it is called via `timeout`
         set -x
 
         watch_build_state() {
@@ -299,16 +266,16 @@ spec:
             echo -n 0 > "$(results.exitCode.path)"
 
             # get the manifest digests
-            indexImageCopy=`cat $(results.jsonBuildInfo.path) | jq -cr .internal_index_image_copy`
+            indexImageCopy=$(jq -cr .internal_index_image_copy < "$(results.jsonBuildInfo.path)")
             # Use this to obtain the manifest digests for each arch in manifest list
-            indexImageDigestsRaw=$(skopeo inspect --raw docker://$indexImageCopy)
+            indexImageDigestsRaw=$(skopeo inspect --raw "docker://${indexImageCopy}")
             # according the IIB team,
             #  "all index images will always be multi-arch with a manifest list"
             #
-            indexImageDigests=$(echo ${indexImageDigestsRaw} | \
+            indexImageDigests=$(echo "${indexImageDigestsRaw}" | \
                jq -r \
                '.manifests[]? | select(.mediaType=="application/vnd.docker.distribution.manifest.v2+json") | .digest')
-            echo -n $indexImageDigests > $(results.indexImageDigests.path)
+            echo -n "${indexImageDigests}" > "$(results.indexImageDigests.path)"
             if [ -z "${indexImageDigests}" ] ; then
               echo "Index image produced is not multi-arch with a manifest list"
               echo -n 1 > "$(results.exitCode.path)"
@@ -316,7 +283,7 @@ spec:
         else
             if [ ${BUILDEXIT} -eq 124 ]; then
                 echo "Timeout while waiting for the build to finish"
-                echo "Build timeout" < $(results.buildState.path)
+                echo "Build timeout" > "$(results.buildState.path)"
             fi
             echo -n "" > "$(results.indexImageDigests.path)"
             echo -n "$BUILDEXIT" > "$(results.exitCode.path)"


### PR DESCRIPTION

this PR fixes the lint issues in the taskiib-add-fbc-fragment-to-index-image-task. In
addition, adjusts the fbc_opt_in code tobe more clear.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>