### PR TITLE
chore: change debug mode to false

### DIFF
--- a/internal-services/config/internal-services/production/internal-services-config.yaml
+++ b/internal-services/config/internal-services/production/internal-services-config.yaml
@@ -8,7 +8,7 @@ spec:
   - rhtap-releng-tenant
   - rh-managed-cnv-fbc-tenant
   - rh-managed-red-hat-acm-tenant
-  debug: true
+  debug: false
   volumeClaim:
     name: pipeline
     size: 1Gi


### PR DESCRIPTION
this PR changes the debug mode of the internal-services operator to false, so it can clean up the resources after finishing the pipelineruns.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>