### PR TITLE
fix: use staging secret for signing pipelines used in stage

### DIFF
--- a/internal-services/config/signing/staging/hacbs-signing-pipeline-config-openshifthosted.yaml
+++ b/internal-services/config/signing/staging/hacbs-signing-pipeline-config-openshifthosted.yaml
@@ -13,7 +13,7 @@ data:
   SIG_KEY_ID: "4096R/37036783 SHA-256"
   SIG_KEY_NAME: "redhate2etesting"
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
-  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
   UMB_URL: "umb.stage.api.redhat.com"

--- a/internal-services/config/signing/staging/hacbs-signing-pipeline-config-redhatbeta2.yaml
+++ b/internal-services/config/signing/staging/hacbs-signing-pipeline-config-redhatbeta2.yaml
@@ -13,7 +13,7 @@ data:
   SIG_KEY_ID: "4096R/37036783 SHA-256"
   SIG_KEY_NAME: "redhate2etesting"
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
-  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
   UMB_URL: "umb.stage.api.redhat.com"

--- a/internal-services/config/signing/staging/hacbs-signing-pipeline-config-redhatrelease2.yaml
+++ b/internal-services/config/signing/staging/hacbs-signing-pipeline-config-redhatrelease2.yaml
@@ -13,7 +13,7 @@ data:
   SIG_KEY_ID: "4096R/37036783 SHA-256"
   SIG_KEY_NAME: "redhate2etesting"
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
-  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
   UMB_URL: "umb.stage.api.redhat.com"


### PR DESCRIPTION
We would like to start using prod RADAS for all signing (see RELEASE-1191 ). As a first step, we changed the secrets that are deployed in staging app sre cluster:

https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/125757

Previouly, we would have two secrets in the stage cluster
 - prod and nonprod. But both would contain the nonprod client cert. With this change, the prod contains prod cert and nonprod contains nonprod cert.

When it got merged, we suddenly started using prod client cert for all signing in stage cluster (e2e) and we thought it might work, but apparently it doesn't and broke e2e.

So instead of reverting that app interface change, let's just change the configMaps to use the nonprod secret.

That way we can keep testing how/if we can use the prod certs to use prod RADAS.