### PR TITLE
chore: re-enabling debug

### DIFF
--- a/internal-services/config/internal-services/production/internal-services-config.yaml
+++ b/internal-services/config/internal-services/production/internal-services-config.yaml
@@ -8,7 +8,7 @@ spec:
   - rhtap-releng-tenant
   - rh-managed-cnv-fbc-tenant
   - rh-managed-red-hat-acm-tenant
-  debug: false
+  debug: true
   volumeClaim:
     name: pipeline
     size: 1Gi


### PR DESCRIPTION
this PR re-enables the debug in InternalServicesConfig. A following up PR will add a cronjob to keep only the last day of internalrequests.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>