### PR TITLE
fix(KFLUXSPRT-794): pass content-gateway token as env var

### DIFF
--- a/internal-services/catalog/pulp-push-disk-images-task.yaml
+++ b/internal-services/catalog/pulp-push-disk-images-task.yaml
@@ -101,7 +101,7 @@ spec:
             secretKeyRef:
               name: $(params.cgwSecret)
               key: username
-        - name: CGW_TOKEN
+        - name: CGW_PASSWORD
           valueFrom:
             secretKeyRef:
               name: $(params.cgwSecret)


### PR DESCRIPTION
- Change name of CGW_TOKEN to CGW_PASSWORD
  - This is actually a token, no pw, but the pubtools library expects this environment variable name
  - Relevant PR to pubtools: https://github.com/release-engineering/pubtools-content-gateway/pull/38
  - Accompanies this open PR: 
      - https://github.com/konflux-ci/release-service-utils/pull/334