### PR TITLE
refactor(RELEASE-1191): add pyxis/umb specific keys to configmaps

### DIFF
--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-openshifthosted.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-openshifthosted.yaml
@@ -15,6 +15,12 @@ data:
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline"
   UMB_URL: "umb.api.redhat.com"
   UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign

--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-redhatbeta2.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-redhatbeta2.yaml
@@ -15,6 +15,12 @@ data:
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline"
   UMB_URL: "umb.api.redhat.com"
   UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign

--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-redhatrelease2.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-redhatrelease2.yaml
@@ -15,6 +15,12 @@ data:
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline"
   UMB_URL: "umb.api.redhat.com"
   UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign

--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-openshifthosted.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-openshifthosted.yaml
@@ -15,6 +15,12 @@ data:
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
   UMB_URL: "umb.stage.api.redhat.com"
   UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign

--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
@@ -15,6 +15,12 @@ data:
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
   UMB_URL: "umb.stage.api.redhat.com"
   UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign

--- a/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatrelease2.yaml
+++ b/internal-services/config/signing/production/hacbs-signing-pipeline-config-staging-redhatrelease2.yaml
@@ -15,6 +15,12 @@ data:
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
   UMB_URL: "umb.stage.api.redhat.com"
   UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign

--- a/internal-services/config/signing/staging/hacbs-signing-pipeline-config-openshifthosted.yaml
+++ b/internal-services/config/signing/staging/hacbs-signing-pipeline-config-openshifthosted.yaml
@@ -15,6 +15,12 @@ data:
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
   UMB_URL: "umb.stage.api.redhat.com"
   UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign

--- a/internal-services/config/signing/staging/hacbs-signing-pipeline-config-redhatbeta2.yaml
+++ b/internal-services/config/signing/staging/hacbs-signing-pipeline-config-redhatbeta2.yaml
@@ -15,6 +15,12 @@ data:
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
   UMB_URL: "umb.stage.api.redhat.com"
   UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign

--- a/internal-services/config/signing/staging/hacbs-signing-pipeline-config-redhatrelease2.yaml
+++ b/internal-services/config/signing/staging/hacbs-signing-pipeline-config-redhatrelease2.yaml
@@ -15,6 +15,12 @@ data:
   SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
   SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
   SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
   UMB_CLIENT_NAME: "hacbs-signing-pipeline-nonprod"
   UMB_URL: "umb.stage.api.redhat.com"
   UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign


### PR DESCRIPTION
This commit modifies the signing configMaps to have pyxis and umb specific ssl keys. They are just copied for now so nothing breaks. The existing ones will be removed at a later date so that only the PYXIS_ and UMB_ ssl keys remain.