### PR TITLE
chore: add simple-signing-pipeline

### DIFF
--- a/internal-services/catalog/sign-image-pipeline.yaml
+++ b/internal-services/catalog/sign-image-pipeline.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: simple-signing-pipeline
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline for image signing via RADAS
+  params:
+    - name: pipeline_image
+      description: An image with CLI tools needed for the signing.
+      default: quay.io/redhat-isv/operator-pipelines-images:released
+
+    - name: manifest_digest
+      description: Manifest digest for the signed content, usually in the format sha256:xxx
+
+    - name: reference
+      description: Docker reference for the signed content, e.g. registry.redhat.io/redhat/community-operator-index:v4.9
+
+    - name: requester
+      description: Name of the user that requested the signing, for auditing purposes
+
+    - name: config_map_name
+      description: A config map name with configuration
+      default: hacbs-signing-pipeline-config
+
+  workspaces:
+    - name: pipeline
+  tasks:
+    - name: set-env
+      taskRef:
+        name: set-env
+      params:
+        - name: config_map_name
+          value: $(params.config_map_name)
+
+    - name: request-signature
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: "quay.io/redhat-isv/tkn-signing-bundle@\
+sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d"
+          - name: name
+            value: request-signature
+          - name: kind
+            value: task
+      runAfter:
+        - set-env
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: manifest_digest
+          value: "$(params.manifest_digest)"
+        - name: reference
+          value: "$(params.reference)"
+        - name: requester
+          value: "$(params.requester)"
+        - name: sig_key_id
+          value: "$(tasks.set-env.results.sig_key_id)"
+        - name: sig_key_name
+          value: "$(tasks.set-env.results.sig_key_name)"
+        - name: umb_ssl_secret_name
+          value: "$(tasks.set-env.results.ssl_cert_secret_name)"
+        - name: umb_ssl_cert_secret_key
+          value: "$(tasks.set-env.results.ssl_cert_file_name)"
+        - name: umb_ssl_key_secret_key
+          value: "$(tasks.set-env.results.ssl_key_file_name)"
+        - name: umb_client_name
+          value: "$(tasks.set-env.results.umb_client_name)"
+        - name: umb_url
+          value: "$(tasks.set-env.results.umb_url)"
+        - name: umb_listen_topic
+          value: "$(tasks.set-env.results.umb_listen_topic)"
+        - name: umb_publish_topic
+          value: "$(tasks.set-env.results.umb_publish_topic)"
+      workspaces:
+        - name: source
+          workspace: pipeline
+          subPath: signing
+
+    - name: upload-signature
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: "quay.io/redhat-isv/tkn-signing-bundle@\
+sha256:72c94ed690baa0f892e69a893520b8089a1008c84f67ee47a19b2dcdd526849d"
+          - name: name
+            value: upload-signature
+          - name: kind
+            value: task
+      runAfter:
+        - request-signature
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: signature_data_file
+          value: "$(tasks.request-signature.results.signature_data_file)"
+        - name: pyxis_ssl_secret_name
+          value: "$(tasks.set-env.results.ssl_cert_secret_name)"
+        - name: pyxis_ssl_cert_secret_key
+          value: "$(tasks.set-env.results.ssl_cert_file_name)"
+        - name: pyxis_ssl_key_secret_key
+          value: "$(tasks.set-env.results.ssl_key_file_name)"
+        - name: pyxis_url
+          value: "$(tasks.set-env.results.pyxis_url)"
+        - name: verify_signature
+          value: "false"
+      workspaces:
+        - name: source
+          workspace: pipeline
+          subPath: signing


### PR DESCRIPTION
this PR adds the simple-sign-pipeline to the stable as the development branch is broken because this
pipeline is missing.