### PR TITLE
chore: add simple-signing-pipeline

### DIFF
--- a/internal-services/catalog/simple-signing-pipeline.yaml
+++ b/internal-services/catalog/simple-signing-pipeline.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: simple-signing-pipeline
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline for simple signing
+  params:
+    - name: pipeline_image
+      description: An image with CLI tools needed for the signing.
+      default: quay.io/redhat-isv/operator-pipelines-images:released
+      type: string
+    - name: manifest_digest
+      description: Manifest digest for the signed content, usually in the format sha256:xxx
+      type: string
+    - name: reference
+      description: Docker reference for the signed content, e.g. registry.redhat.io/redhat/community-operator-index:v4.9
+      type: string
+    - name: requester
+      description: Name of the user that requested the signing, for auditing purposes
+      type: string
+    - name: config_map_name
+      description: A config map name with configuration
+      default: hacbs-signing-pipeline-config
+      type: string
+    - name: taskGitUrl
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+      type: string
+    - name: taskGitRevision
+      description: The revision in the taskGitUrl repo to be used
+      type: string
+  workspaces:
+    - name: pipeline
+  tasks:
+    - name: collect-simple-signing-params
+      retries: 5
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/collect-simple-signing-params/collect-simple-signing-params.yaml
+      params:
+        - name: config_map_name
+          value: $(params.config_map_name)
+    - name: request-and-upload-signature
+      retries: 5
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/request-and-upload-signature/request-and-upload-signature.yaml
+      params:
+        - name: config_map_name
+          value: $(params.config_map_name)
+        - name: manifest_digest
+          value: $(params.manifest_digest)
+        - name: reference
+          value: $(params.reference)
+        - name: requester
+          value: $(params.requester)
+        - name: sig_key_id
+          value: $(tasks.collect-simple-signing-params.results.sig_key_id)
+        - name: sig_key_name
+          value: $(tasks.collect-simple-signing-params.results.sig_key_name)
+        - name: ssl_cert_secret_name
+          value: $(tasks.collect-simple-signing-params.results.ssl_cert_secret_name)
+        - name: ssl_cert_file_name
+          value: $(tasks.collect-simple-signing-params.results.ssl_cert_file_name)
+        - name: ssl_key_file_name
+          value: $(tasks.collect-simple-signing-params.results.ssl_key_file_name)
+        - name: umb_client_name
+          value: $(tasks.collect-simple-signing-params.results.umb_client_name)
+        - name: umb_listen_topic
+          value: $(tasks.collect-simple-signing-params.results.umb_listen_topic)
+        - name: umb_publish_topic
+          value: $(tasks.collect-simple-signing-params.results.umb_publish_topic)
+        - name: umb_url
+          value: $(tasks.collect-simple-signing-params.results.umb_url)
+        - name: pyxis_ssl_secret_name
+          value: $(tasks.collect-simple-signing-params.results.ssl_cert_secret_name)
+        - name: pyxis_ssl_cert_secret_key
+          value: $(tasks.collect-simple-signing-params.results.ssl_cert_file_name)
+        - name: pyxis_ssl_key_secret_key
+          value: $(tasks.collect-simple-signing-params.results.ssl_key_file_name)
+        - name: pyxis_url
+          value: $(tasks.collect-simple-signing-params.results.pyxis_url)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+      workspaces:
+        - name: data
+          workspace: pipeline
+          subPath: signing
+      runAfter:
+        - collect-simple-signing-params


### PR DESCRIPTION
Temporary addition to the stable branch until it is in release-service-catalog production.