### PR TITLE
fix: update utils image in push-disk-images task

### DIFF
--- a/internal-services/catalog/pulp-push-disk-images-task.yaml
+++ b/internal-services/catalog/pulp-push-disk-images-task.yaml
@@ -42,7 +42,7 @@ spec:
       description: Success if the task succeeds, the error otherwise
   steps:
     - name: pull-and-push-images
-      image: quay.io/konflux-ci/release-service-utils:50b8874d0ce2ba56e3a290bd39827398eec35263
+      image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
       env:
         - name: EXODUS_CERT
           valueFrom:


### PR DESCRIPTION
The script called in the pulp-push-disk-images task started failing because `packaging` was not explicitly installed in the utils image. Now that it is, the utils image is bumped to fix the error.