### PR TITLE
fix: update utils image in push-disk-images task

### DIFF
--- a/internal-services/catalog/pulp-push-disk-images-task.yaml
+++ b/internal-services/catalog/pulp-push-disk-images-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: pulp-push-disk-images
   labels:
-    app.kubernetes.io/version: "0.2.2"
+    app.kubernetes.io/version: "0.2.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -42,7 +42,7 @@ spec:
       description: Success if the task succeeds, the error otherwise
   steps:
     - name: pull-and-push-images
-      image: quay.io/konflux-ci/release-service-utils:6556e8a6b031c1aad4f0472703fd121a6e1cd45d
+      image: quay.io/konflux-ci/release-service-utils:597145c2cbcff9e99e1c62169eccab003e68c157
       env:
         - name: EXODUS_CERT
           valueFrom:
@@ -257,7 +257,7 @@ spec:
         while IFS= read -r -d '' file ; do
             STAGED_JSON=$(jq --arg filename "$(basename "$file")" --arg path "$file" \
               --arg version "$VERSION" \
-              '.payload.files[.payload.files | length] = 
+              '.payload.files[.payload.files | length] =
               {"filename": $filename, "relative_path": $path, "version": $version}' <<< "$STAGED_JSON")
         done < <(find * -type f -print0)
 


### PR DESCRIPTION
The image was updated recently to get a fix for a missing packaging python module:
https://github.com/hacbs-release/app-interface-deployments/pull/256

But the new image introduced a regression in the
select-oci-auth script. So now it's fixed in this new image: https://github.com/konflux-ci/release-service-utils/pull/341