### PR TITLE
chore(RELEASE-1242): make add-fbc-contribution idempotent

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: t-add-fbc-fragment-to-index-image
   labels:
-    app.kubernetes.io/version: "0.3.1"
+    app.kubernetes.io/version: "0.4.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -19,6 +19,10 @@ spec:
       type: string
       description: ->
         Index image (catalog of catalogs) the FBC fragment will be added to
+    - name: targetIndex
+      type: string
+      description: ->
+        Target index is the pullspec the FBC catalog will be pushed to
     - name: buildTags
       type: string
       description: ->
@@ -82,65 +86,93 @@ spec:
               key: krb5.conf
       script: |
         #!/usr/bin/env bash
-        #
-        isfbcOptIn() {
+
+        isFBCOptIn() {
           TMPFILE=$(mktemp)
           PYXIS_URL="https://pyxis.engineering.redhat.com/v1"
 
-          IFS="/" read REGISTRY REPO IMAGE <<< "${1}"
-          IFS=":" read IMAGE TAG <<< "${IMAGE}"
+          IFS="/" read -r REGISTRY REPO IMAGE <<< "${1}"
+          IFS=":" read -r IMAGE TAG <<< "${IMAGE}"
 
           FETCH_URL="${PYXIS_URL}/repositories/registry/${REGISTRY}/repository/${REPO}/${IMAGE}/tag/${TAG}"
 
           # strips the last "/tag" in case $TAG is not set
           [ -z "${TAG}" ] && FETCH_URL=${FETCH_URL%/tag*}
 
-          curl --negotiate -u: "${FETCH_URL}" -o $TMPFILE
+          curl --negotiate -u: "${FETCH_URL}" -o "${TMPFILE}"
+
           # prints "false" in case .fbc_opt_in entry is missing
-          jq -e -r '.fbc_opt_in //false' $TMPFILE && rm -f $TMPFILE
+          jq -e -r '.fbc_opt_in //false' "${TMPFILE}" && rm -f "${TMPFILE}"
+        }
+
+        # checks if there is any previous build for the same fbc_fragment.
+        # in case multiple builds are found, returns only the last one.
+        check_previous_build() {
+          user="${1}"
+          from_index="${2}"
+          fbc_fragment="${3}"
+
+          # fetch only builds in progress or completed
+          build=$(curl -s "${IIB_SERVICE_URL}/builds?user=${user}&from_index=${from_index}" | \
+            jq --arg fbc_fragment "${fbc_fragment}" \
+              '[.items[] |select(.fbc_fragment==$fbc_fragment and .state!="failed")][0] // empty')
+
+          if [ "$(jq -r '.state' <<< "${build}")" = "complete" ]; then
+            indexImageResolved="$(jq -r '.index_image_resolved' <<<  "${build}")"
+            newCatalogCreatedDate="$(date --date "$(skopeo inspect --config "docker://${indexImageResolved}" | \
+              jq -r .created)" "+%s")"
+            upstreamCatalogCreatedDate="$(date --date "$(skopeo inspect --config "docker://$(params.targetIndex)" | \
+              jq -r .created)" "+%s")"
+            # checks if the index_image_resolved in the previous completed build is newer
+            # than the upstream catalog index.
+            # in case the new catalog index is older than the upstream, a new build is
+            # required to assure the catalog integrity.
+            if [ "${newCatalogCreatedDate}" -gt "${upstreamCatalogCreatedDate}" ]; then
+              echo "${build}"
+            fi
+          fi
         }
 
         # performs kerberos authentication.
         base64 -d /mnt/service-account-secret/keytab > /tmp/keytab
 
         KRB5_TEMP_CONF=$(mktemp)
+        KRB5_PRINCIPAL=$(cat /mnt/service-account-secret/principal)
+
         echo "${KRB5_CONF_CONTENT}" > "${KRB5_TEMP_CONF}"
         export KRB5_CONFIG="${KRB5_TEMP_CONF}"
         export KRB5_TRACE=/dev/stderr
 
-        /usr/bin/kinit -V $(cat /mnt/service-account-secret/principal) -k -t /tmp/keytab
+        /usr/bin/kinit -V "${KRB5_PRINCIPAL}" -k -t /tmp/keytab
 
         set -x
         # check if this fbc fragment is opt-in
         echo "Fetching the image bundle from $(params.fbcFragment)..."
-        PULL_SPEC_LIST=$(opm render $(params.fbcFragment) | jq -r \
+        PULL_SPEC_LIST=$(opm render "$(params.fbcFragment)" | jq -r \
         'select(.schema == "olm.bundle") | "\(.image)" | split("@")[0]' |uniq)
+
+        fbcOptIn="true"
         for PULL_SPEC in ${PULL_SPEC_LIST}; do
             # make sure they query is done using the internal name instead of the public
-            PULL_SPEC=$(sed  's/registry.redhat.io/registry.access.redhat.com/g' <<< $PULL_SPEC)
-
+            PULL_SPEC="${PULL_SPEC//registry.redhat.io/registry.access.redhat.com}"
             echo "Attempting to fetch from ${FETCH_URL} to check if fragment is \`fbc_opt_in==true\`..."
-            fbcOptIn+=(`isfbcOptIn ${PULL_SPEC}`)
+            if [ "$(isFBCOptIn "${PULL_SPEC}")" = "false" ]; then
+              fbcOptIn="false"
+              break
+            fi
         done
-
-        fbcOptIn=($(printf "%s\n" ${fbcOptIn[@]} |sort |uniq))
-        mustPublishIndexImage=$fbcOptIn
-        mustSignIndexImage=$fbcOptIn
+        mustOverwriteFromIndexImage="${fbcOptIn}"
+        mustPublishIndexImage="${fbcOptIn}"
+        mustSignIndexImage="${fbcOptIn}"
 
         if [ "$(params.hotfix)" == "true" ]; then
             echo "Hotfix build"
-            fbcOptIn="false"
+            mustOverwriteFromIndexImage="false"
             mustSignIndexImage="true"
             mustPublishIndexImage="true"
         elif [ "$(params.stagedIndex)" == "true" ]; then
             echo "Staged Index build"
-            fbcOptIn="false"
-            mustSignIndexImage="false"
-            mustPublishIndexImage="false"
-
-        # in case of more than one image all should have the same fbc_opt_in value
-        elif [ $(wc -w <<< ${fbcOptIn[@]}) -ne 1 ]; then
-            fbcOptIn="false"
+            mustOverwriteFromIndexImage="false"
             mustSignIndexImage="false"
             mustPublishIndexImage="false"
         fi
@@ -149,6 +181,8 @@ spec:
         echo "             \`mustPublishIndexImage==${mustPublishIndexImage}\`"
         echo "             \`mustSignIndexImage==${mustSignIndexImage}\`"
 
+        # these results will be used by add-fbc-contribution to control
+        # signing and publishing of the built fragment
         jq -n -c \
            --arg fbc_opt_in "${fbcOptIn}" \
            --arg publish_index_image "${mustPublishIndexImage}" \
@@ -157,7 +191,16 @@ spec:
              "fbc_opt_in": $fbc_opt_in,
              "publish_index_image": $publish_index_image,
              "sign_index_image": $sign_index_image
-            } | tostring' | tee $(results.genericResult.path)
+            } | tostring' | tee "$(results.genericResult.path)"
+
+        # if it finds a build which is completed or in progress, it should exit this step and jump to
+        # the next step `s-wait-for-build-state` which will watch the build until it is completed.
+        build=$(check_previous_build "${KRB5_PRINCIPAL}" "$(params.fromIndex)" "$(params.fbcFragment)")
+        if [ -n "${build}" ]; then
+          echo "=== A previous build for this fragment was found ==="
+          echo "${build}" |tee "$(results.jsonBuildInfo.path)"
+          exit 0
+        fi
 
         # adds the json request parameters to a file to be used as input data
         # for curl and preventing shell expansion.
@@ -168,9 +211,9 @@ spec:
         {
           "fbc_fragment": "$(params.fbcFragment)",
           "from_index": "$(params.fromIndex)",
-          "build_tags": `echo $(params.buildTags)`,
-          "add_arches": `echo $(params.addArches)`,
-          "overwrite_from_index": ${fbcOptIn},
+          "build_tags": $(params.buildTags),
+          "add_arches": $(params.addArches),
+          "overwrite_from_index": ${mustOverwriteFromIndexImage},
           "overwrite_from_index_token": "${IIB_OVERWRITE_FROM_INDEX_USERNAME}:${IIB_OVERWRITE_FROM_INDEX_TOKEN}"
         }
         JSON
@@ -181,13 +224,13 @@ spec:
           if(.add_arches | length) == 0 then del(.add_arches) else . end |
           if(.build_tags | length) == 0 then del(.build_tags) else . end' ${json_raw_input} > ${json_input}
 
-        echo "Calling IIB endpoint" > $(results.buildState.path)
+        echo "Calling IIB endpoint" > "$(results.buildState.path)"
         # adds image to the index.
         /usr/bin/curl -u : --negotiate -s -X POST -H "Content-Type: application/json" -d@${json_input} --insecure \
-        "${IIB_SERVICE_URL}/builds/fbc-operations" |tee $(results.jsonBuildInfo.path)
+        "${IIB_SERVICE_URL}/builds/fbc-operations" |tee "$(results.jsonBuildInfo.path)"
 
         # checks if the previous call returned an error.
-        ! jq -e -r ".error | select( . != null )" $(results.jsonBuildInfo.path)
+        ! jq -e -r ".error | select( . != null )" "$(results.jsonBuildInfo.path)"
       volumeMounts:
         - name: service-account-secret
           mountPath: /mnt/service-account-secret
@@ -203,7 +246,6 @@ spec:
       script: |
         #!/usr/bin/env bash
         # shellcheck disable=SC2317 # shellcheck calls all the commands in the function unreachable
-        # because it is called via `timeout`
         set -x
 
         watch_build_state() {
@@ -243,16 +285,16 @@ spec:
             echo -n 0 > "$(results.exitCode.path)"
 
             # get the manifest digests
-            indexImageCopy=`cat $(results.jsonBuildInfo.path) | jq -cr .internal_index_image_copy`
+            indexImageCopy=$(jq -cr .internal_index_image_copy < "$(results.jsonBuildInfo.path)")
             # Use this to obtain the manifest digests for each arch in manifest list
-            indexImageDigestsRaw=$(skopeo inspect --raw docker://$indexImageCopy)
+            indexImageDigestsRaw=$(skopeo inspect --raw "docker://${indexImageCopy}")
             # according the IIB team,
             #  "all index images will always be multi-arch with a manifest list"
             #
-            indexImageDigests=$(echo ${indexImageDigestsRaw} | \
+            indexImageDigests=$(echo "${indexImageDigestsRaw}" | \
                jq -r \
                '.manifests[]? | select(.mediaType=="application/vnd.docker.distribution.manifest.v2+json") | .digest')
-            echo -n $indexImageDigests > $(results.indexImageDigests.path)
+            echo -n "${indexImageDigests}" > "$(results.indexImageDigests.path)"
             if [ -z "${indexImageDigests}" ] ; then
               echo "Index image produced is not multi-arch with a manifest list"
               echo -n 1 > "$(results.exitCode.path)"
@@ -260,7 +302,7 @@ spec:
         else
             if [ ${BUILDEXIT} -eq 124 ]; then
                 echo "Timeout while waiting for the build to finish"
-                echo "Build timeout" < $(results.buildState.path)
+                echo "Build timeout" > "$(results.buildState.path)"
             fi
             echo -n "" > "$(results.indexImageDigests.path)"
             echo -n "$BUILDEXIT" > "$(results.exitCode.path)"

--- a/internal-services/catalog/iib-pipeline.yaml
+++ b/internal-services/catalog/iib-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: iib
   labels:
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/version: "0.6.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: fbc
@@ -23,6 +23,10 @@ spec:
       type: string
       description: ->
         Index image (catalog of catalogs) the FBC fragment will be added to
+    - name: targetIndex
+      type: string
+      description: ->
+        Target index is the pullspec the FBC catalog will be pushed to
     - name: buildTags
       type: string
       default: '[]'
@@ -55,6 +59,8 @@ spec:
           value: $(params.fbcFragment)
         - name: fromIndex
           value: $(params.fromIndex)
+        - name: targetIndex
+          value: $(params.targetIndex)
         - name: buildTags
           value: $(params.buildTags)
         - name: addArches


### PR DESCRIPTION
This PR modifies the task add-fbc-fragment-to-index-image idempotent by checking IIB endpoint for builds for the current fbc_fragment, considering only prod builds and builds complete or in progress.

In addition, it contains code for RELEASE-1338 which the referenced ticket in the title depended on.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>