### PR TITLE
fix: fbc release not resuming when in progress

### DIFF
--- a/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
+++ b/internal-services/catalog/iib-add-fbc-fragment-to-index-image-task.yaml
@@ -129,7 +129,10 @@ spec:
             # required to assure the catalog integrity.
             if [ "${newCatalogCreatedDate}" -gt "${upstreamCatalogCreatedDate}" ]; then
               echo "${build}"
+              return 0
             fi
+          else
+            echo "${build}"
           fi
         }
 


### PR DESCRIPTION
this PR fixes the case when a in progress IIB build is to be resumed, it actually resumes it.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>