### PR TITLE
feature(CLDX-294): add developer-portal service account

### DIFF
--- a/internal-services/rbac/service_account.yaml
+++ b/internal-services/rbac/service_account.yaml
@@ -18,3 +18,21 @@ metadata:
   namespace: stonesoup-int-srvc
 secrets:
 - name: redhat-workloads-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-developer-portal
+  namespace: stonesoup-int-srvc
+secrets:
+  - name: quay-credentials
+  - name: windows-credentials
+  - name: mac-host-credentials
+  - name: mac-signing-credentials
+  - name: checksum-fingerprint
+  - name: checksum-keytab
+  - name: windows-ssh-key
+  - name: mac-ssh-key
+  - name: publish-to-cgw-secret
+  - name: exodus-prod-secret
+  - name: create-advisory-poc-secret


### PR DESCRIPTION
This PR allows konflux relengs to use the release-developer-portal service account for InternalRequests testing

Signed-off-by: Scott Wickersham swickers@redhat.com