### PR TITLE
revert: rollback prod operator

### DIFF
--- a/internal-services/manager/production/manager-prod-ocp-p01.yaml
+++ b/internal-services/manager/production/manager-prod-ocp-p01.yaml
@@ -61,7 +61,7 @@ spec:
             - /mnt/internal-services/remote-client-config/kubeconfig
             - --leader-election-id
             - "prod-ocp-p01"
-          image: quay.io/konflux-ci/internal-services:ea7baebdd59db96529424e335fd0854c7f66baab
+          image: quay.io/konflux-ci/internal-services:b2c8a902ca00a9a6fe14ea2778733f427a02ebec
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/production/manager-prod-p01.yaml
+++ b/internal-services/manager/production/manager-prod-p01.yaml
@@ -61,7 +61,7 @@ spec:
             - /mnt/internal-services/remote-client-config/kubeconfig
             - --leader-election-id
             - "prod-p01"
-          image: quay.io/konflux-ci/internal-services:ea7baebdd59db96529424e335fd0854c7f66baab
+          image: quay.io/konflux-ci/internal-services:b2c8a902ca00a9a6fe14ea2778733f427a02ebec
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/production/manager-prod-p02.yaml
+++ b/internal-services/manager/production/manager-prod-p02.yaml
@@ -61,7 +61,7 @@ spec:
             - /mnt/internal-services/remote-client-config/kubeconfig
             - --leader-election-id
             - "prod-p02"
-          image: quay.io/konflux-ci/internal-services:ea7baebdd59db96529424e335fd0854c7f66baab
+          image: quay.io/konflux-ci/internal-services:b2c8a902ca00a9a6fe14ea2778733f427a02ebec
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/production/manager-prod-rh01.yaml
+++ b/internal-services/manager/production/manager-prod-rh01.yaml
@@ -59,7 +59,7 @@ spec:
             - --leader-elect
             - --remote-cluster-config-file
             - /mnt/internal-services/remote-client-config/kubeconfig
-          image: quay.io/konflux-ci/internal-services:ea7baebdd59db96529424e335fd0854c7f66baab
+          image: quay.io/konflux-ci/internal-services:b2c8a902ca00a9a6fe14ea2778733f427a02ebec
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/production/manager-prod-rh02.yaml
+++ b/internal-services/manager/production/manager-prod-rh02.yaml
@@ -61,7 +61,7 @@ spec:
             - /mnt/internal-services/remote-client-config/kubeconfig
             - --leader-election-id
             - "prod-rh02"
-          image: quay.io/konflux-ci/internal-services:ea7baebdd59db96529424e335fd0854c7f66baab
+          image: quay.io/konflux-ci/internal-services:b2c8a902ca00a9a6fe14ea2778733f427a02ebec
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/staging/manager-staging-p01.yaml
+++ b/internal-services/manager/staging/manager-staging-p01.yaml
@@ -61,7 +61,7 @@ spec:
             - /mnt/internal-services/remote-client-config/kubeconfig
             - --leader-election-id
             - "staging-p01"
-          image: quay.io/konflux-ci/internal-services:ea7baebdd59db96529424e335fd0854c7f66baab
+          image: quay.io/konflux-ci/internal-services:b2c8a902ca00a9a6fe14ea2778733f427a02ebec
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal-services/manager/staging/manager-staging-rh01.yaml
+++ b/internal-services/manager/staging/manager-staging-rh01.yaml
@@ -59,7 +59,7 @@ spec:
             - --leader-elect
             - --remote-cluster-config-file
             - /mnt/internal-services/remote-client-config/kubeconfig
-          image: quay.io/konflux-ci/internal-services:ea7baebdd59db96529424e335fd0854c7f66baab
+          image: quay.io/konflux-ci/internal-services:b2c8a902ca00a9a6fe14ea2778733f427a02ebec
           name: manager
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
This commit rolls back PR 303, which removed
InternalRequest.Spec.Request in the operator in prod/stable.