### PR TITLE
chore(RELEASE-1673): change cronjob periodicity (stable)

### DIFF
--- a/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
+++ b/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cleanup-internal-requests-pipelineruns
   namespace: stonesoup-int-srvc
 spec:
-  schedule: "10 03 * * *"
+  schedule: "10 * * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
@@ -25,7 +25,7 @@ spec:
                 - name: CR_NAMESPACE
                   value: "stonesoup-int-srvc"
                 - name: OLDER_THAN
-                  value: "yesterday"
+                  value: "12 hours ago"
                 - name: LABELS
                   value: "pipelines.appstudio.openshift.io/type=release"
               command:


### PR DESCRIPTION
this PR changes the internal request clean up
cronjob to run hourly, and deleting pipelineruns
older than 12 hours.