### PR TITLE
chore(RELEASE-1738): disable manager for stage p01

### DIFF
--- a/internal-services/manager/staging/manager-staging-p01.yaml
+++ b/internal-services/manager/staging/manager-staging-p01.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       annotations:
@@ -24,7 +24,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:


### PR DESCRIPTION
- we will use stage p01 as a test environment for testing the new Konflux common clusters
- set replicas to 0 so we can run the manager on another cluster instead of appsre cluster.