### PR TITLE
chore(KONFLUX-7648): enable renovate to bump utils image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":disableDependencyDashboard",
+    ":gitSignOff"
+  ],
+  "timezone": "UTC",
+  "commitMessagePrefix": "chore(deps):",
+  "commitMessageAction": "update",
+  "enabledManagers": ["kubernetes"],
+  "kubernetes": {
+    "managerFilePatterns": ["**/*.yaml"]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["kubernetes"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["quay.io/konflux-ci/release-service-utils"],
+      "pinDigests": true,
+      "schedule": [
+        "on wednesday at 2pm"
+      ]
+    }
+  ]
+}

--- a/.gitlint
+++ b/.gitlint
@@ -12,3 +12,7 @@ line-length=72
 [body-first-line-empty]
 
 [contrib-title-conventional-commits]
+
+[ignore-by-author-name]
+regex=(.*)\[bot\](.*)
+ignore=T1,B1

--- a/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
+++ b/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
@@ -68,7 +68,7 @@ spec:
                   export -f deleteAndLog
                   xargs -a ${PRUNING_CRS_FILE} -i -P ${MAX_PROCS} bash -c 'deleteAndLog "{}"'
               imagePullPolicy: IfNotPresent
-              image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+              image: quay.io/konflux-ci/release-service-utils@sha256:2243945e96beb0f26125a68fec7fa55b6791463ec1bdf62dcf6a003a36bd0959
               volumeMounts:
                 - mountPath: /var/tmp
                   name: temp-directory


### PR DESCRIPTION
chore(deps): enable renovate to bump utils image
* Add Renovate JSON config to bump utils image weekly on Wednesday at 14:00 UTC
* Pin image references to digests
* Updates .gitlint to ignore Renovate bot PRs.

Related Tickets: KONFLUX-7804 & KONFLUX-7648
Tested here: https://github.com/seanconroy2021/test-renovate/pull/23