### PR TITLE
chore(RELEASE-1828): convert utils image to digest format

### DIFF
--- a/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
+++ b/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
@@ -68,7 +68,7 @@ spec:
                   export -f deleteAndLog
                   xargs -a ${PRUNING_CRS_FILE} -i -P ${MAX_PROCS} bash -c 'deleteAndLog "{}"'
               imagePullPolicy: IfNotPresent
-              image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+              image: quay.io/konflux-ci/release-service-utils@sha256:2243945e96beb0f26125a68fec7fa55b6791463ec1bdf62dcf6a003a36bd0959
               volumeMounts:
                 - mountPath: /var/tmp
                   name: temp-directory


### PR DESCRIPTION
Switch the utils image in the CronJob from a tag to a  digest so the promotion workflow can run. Image digest is from main.
