### PR TITLE
chore: add pr reviewer auto-assignment WF to stable

### DIFF
--- a/.github/workflows/pr-assigner.yaml
+++ b/.github/workflows/pr-assigner.yaml
@@ -1,0 +1,23 @@
+---
+name: Assign PR
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, unassigned]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign reviewers using shared action
+        uses: konflux-ci/release-service-automations/pr-assigner@95b18b7c384f4f4d698c17f2476b8ab0cc8cc3ab  # main
+        with:
+          event-type: ${{ github.event.action }}
+          pr-number: ${{ github.event.pull_request.number }}
+          removed-assignee: ${{ github.event.action == 'unassigned' && github.event.assignee.login || '' }}
+          github-token: ${{ secrets.PR_ASSIGNER_PAT_TOKEN }}
+          slack-webhook: ${{ secrets.PR_ASSIGNER_SLACK_WEBHOOK }}


### PR DESCRIPTION
add pr reviewer auto-assignment workflow to the main branch. WF taken from RSC.
