### PR TITLE
chore: remove CODEOWNERS file main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# hacbs-release/release-service-maintainers  will be requested for
-# review when someone opens a pull request.
-*       @hacbs-release/release-service-maintainers 


### PR DESCRIPTION
Remove the CODEOWNERS file from the main branch now that PR reviewer auto-assignment is handled by our workflow.

