### PR TITLE
chore(RELEASE-1862): scale down stage manager rh01 to 0 replicas

### DIFF
--- a/internal-services/manager/staging/manager-staging-rh01.yaml
+++ b/internal-services/manager/staging/manager-staging-rh01.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       annotations:


### PR DESCRIPTION
We will use the common cluster instead of app-sre going forward.