### PR TITLE
chore(RELEASE-1863): scale prod p01 manager to 0 replicas

### DIFF
--- a/internal-services/manager/production/manager-prod-p01.yaml
+++ b/internal-services/manager/production/manager-prod-p01.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       annotations:


### PR DESCRIPTION
This commit scales the stone-prod-p01 manager replicas to 0. This will turn off the app-sre cluster for stone-prod-p01, which will be replaced with the common cluster.