### PR TITLE
chore(RELEASE-1863): scale down all prod managers

### DIFF
--- a/internal-services/manager/production/manager-prod-ocp-p01.yaml
+++ b/internal-services/manager/production/manager-prod-ocp-p01.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       annotations:

--- a/internal-services/manager/production/manager-prod-osp-p01.yaml
+++ b/internal-services/manager/production/manager-prod-osp-p01.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       annotations:

--- a/internal-services/manager/production/manager-prod-p02.yaml
+++ b/internal-services/manager/production/manager-prod-p02.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       annotations:

--- a/internal-services/manager/production/manager-prod-rh01.yaml
+++ b/internal-services/manager/production/manager-prod-rh01.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       annotations:

--- a/internal-services/manager/production/manager-prod-rh02.yaml
+++ b/internal-services/manager/production/manager-prod-rh02.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       annotations:

--- a/internal-services/manager/production/manager-prod-rh03.yaml
+++ b/internal-services/manager/production/manager-prod-rh03.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       annotations:

--- a/internal-services/manager/production/manager-prod-rhel-p01.yaml
+++ b/internal-services/manager/production/manager-prod-rhel-p01.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       annotations:


### PR DESCRIPTION
This commit scales down the remaining production managers to 0 replicas as they will be replaced by ones on the new common cluster.